### PR TITLE
Unverified email login message

### DIFF
--- a/km_api/account/authentication.py
+++ b/km_api/account/authentication.py
@@ -43,8 +43,7 @@ class AuthenticationBackend:
         email = email or username
 
         try:
-            email_instance = models.EmailAddress.objects.get(
-                email=email, verified=True)
+            email_instance = models.EmailAddress.objects.get(email=email)
         except models.EmailAddress.DoesNotExist:
             return None
 

--- a/km_api/account/serializers.py
+++ b/km_api/account/serializers.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model, password_validation
 from django.utils.translation import ugettext as _
 
+from django.contrib.auth import authenticate
+
 from rest_framework import serializers
 
 from account import models
@@ -208,15 +210,13 @@ class EmailVerificationSerializer(serializers.Serializer):
                 associated with the confirmation.
         """
         confirmation = models.EmailConfirmation.objects.get(key=data['key'])
-        user = confirmation.email.user
+        user = authenticate(
+            email=confirmation.email.email,
+            password=data['password'])
 
-        if not user.check_password(data['password']):
+        if not user:
             raise serializers.ValidationError(
                 _('The provided credentials were invalid.'))
-
-        if not user.is_active:
-            raise serializers.ValidationError(
-                _('This account is marked as inactive'))
 
         data['confirmation'] = confirmation
 

--- a/km_api/account/tests/authentication/test_authentication_backend.py
+++ b/km_api/account/tests/authentication/test_authentication_backend.py
@@ -37,26 +37,6 @@ def test_authenticate_invalid_password(
         'notpassword') is None
 
 
-def test_authenticate_unverified_email(
-        auth_backend,
-        api_rf,
-        user_factory,
-        email_factory):
-    """
-    If the user has not validated their email, None should be
-    returned.
-    """
-    user = user_factory(password='password')
-    email = email_factory(user=user, verified=False)
-
-    request = api_rf.get('/')
-
-    assert auth_backend.authenticate(
-        request,
-        username=email.email,
-        password='password') is None
-
-
 def test_authenticate_missing_email(auth_backend, api_rf, user_factory):
     """
     If the provided email address doesn't exist, ``None`` should be

--- a/km_api/km_auth/serializers.py
+++ b/km_api/km_auth/serializers.py
@@ -63,6 +63,10 @@ class TokenSerializer(serializers.Serializer):
                 _('Invalid credentials. Check your email and password and try'
                   'again.'))
 
+        if not user.email_addresses.get(email=data['email']).verified:
+            raise serializers.ValidationError(
+                _('You must verify this email address before logging in.'))
+
         data['user'] = user
 
         return data


### PR DESCRIPTION
This change restores the more descriptive error message that was previously present for users who try to log in with an unverified email address. Rather than giving them an `invalid credentials` response, we tell them that their email needs to be verified before they can sign in.

A side effect of this change is that we had to revert #60.

Fixes #70