### PR TITLE
Update Know Me user endpoints

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,13 +4,14 @@ Changelog
 v0.5
 ----
 
-Breaking Changes
-  * :issue:`65`: Renamed most models. This will cause existing data to disappear.
-  * :issue:`85`: Move profile item content related to images to separate model.
+This release was focused on renaming the components of a Know Me user's profile. As a result of this renaming, this release will break all existing data related to Know Me. This change also caused several endpoints to be renamed. The most relevant issue here is :issue:`65`.
+
+* ``/know-me/gallery-items/*`` to ``/know-me/media-resources/*``
+* ``/know-me/profiles/*`` to ``/know-me/users/*``
+* ``/know-me/rows/*`` to ``/know-me/topics/*``
 
 Bug Fixes
   * :issue:`75`: Fix parsing of JSON requests.
-  * :issue:`95`: Renamed ProfileRow to ProfileTopic.
 
 v0.4
 ----

--- a/km_api/know_me/tests/views/test_km_user_detail_view.py
+++ b/km_api/know_me/tests/views/test_km_user_detail_view.py
@@ -8,7 +8,8 @@ km_user_detail_view = views.KMUserDetailView.as_view()
 
 def test_get_own_km_user(api_rf, km_user_factory, user_factory):
     """
-    A user should be able to get the details of their own km_user.
+    A user should be able to get the details of their own Know Me user
+    account.
     """
     user = user_factory()
     api_rf.user = user
@@ -29,7 +30,7 @@ def test_get_own_km_user(api_rf, km_user_factory, user_factory):
 def test_update(api_rf, km_user_factory, user_factory):
     """
     Sending a PATCH request to the view should update the specified
-    km_user.
+    Know Me user.
     """
     user = user_factory()
     api_rf.user = user

--- a/km_api/know_me/tests/views/test_km_user_list_view.py
+++ b/km_api/know_me/tests/views/test_km_user_list_view.py
@@ -35,8 +35,8 @@ def test_create(api_rf, user_factory):
 
 def test_create_second_km_user(api_rf, km_user_factory, user_factory):
     """
-    A user who already has a km_user should not be able to create a
-    second one.
+    A user who already has an associated ``KMUser`` instance should not
+    be able to create a second one.
     """
     user = user_factory()
     api_rf.user = user

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -11,10 +11,10 @@ urlpatterns = [
     url(r'^groups/(?P<pk>[0-9]+)/$', views.ProfileGroupDetailView.as_view(), name='profile-group-detail'),          # noqa
     url(r'^groups/(?P<pk>[0-9]+)/topics/$', views.ProfileTopicListView.as_view(), name='profile-topic-list'),             # noqa
     url(r'^items/(?P<pk>[0-9]+)/$', views.ProfileItemDetailView.as_view(), name='profile-item-detail'),             # noqa
-    url(r'^profiles/$', views.KMUserListView.as_view(), name='km-user-list'),
-    url(r'^profiles/(?P<pk>[0-9])/$', views.KMUserDetailView.as_view(), name='km-user-detail'),                    # noqa
-    url(r'^profiles/(?P<pk>[0-9])/gallery/$', views.GalleryView.as_view(), name='gallery'),                         # noqa
-    url(r'^profiles/(?P<pk>[0-9])/groups/$', views.ProfileGroupListView.as_view(), name='profile-group-list'),      # noqa
     url(r'^topics/(?P<pk>[0-9]+)/$', views.ProfileTopicDetailView.as_view(), name='profile-topic-detail'),                # noqa
     url(r'^topics/(?P<pk>[0-9]+)/items/$' ,views.ProfileItemListView.as_view(), name='profile-item-list'),            # noqa
+    url(r'^users/$', views.KMUserListView.as_view(), name='km-user-list'),
+    url(r'^users/(?P<pk>[0-9])/$', views.KMUserDetailView.as_view(), name='km-user-detail'),                    # noqa
+    url(r'^users/(?P<pk>[0-9])/gallery/$', views.GalleryView.as_view(), name='gallery'),                         # noqa
+    url(r'^users/(?P<pk>[0-9])/groups/$', views.ProfileGroupListView.as_view(), name='profile-group-list'),      # noqa
 ]

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -35,15 +35,6 @@ class GalleryView(generics.CreateAPIView):
         return serializer.save(km_user=km_user)
 
 
-class MediaResourceDetailView(generics.RetrieveUpdateAPIView):
-    """
-    View for retrieving and updating a specific media resource.
-    """
-    permission_classes = (DRYPermissions,)
-    queryset = models.MediaResource.objects.all()
-    serializer_class = serializers.MediaResourceSerializer
-
-
 class KMUserDetailView(generics.RetrieveUpdateAPIView):
     """
     View for retreiving and updating a specific km_user.
@@ -64,21 +55,31 @@ class KMUserListView(generics.ListCreateAPIView):
 
     def perform_create(self, serializer):
         """
-        Create a new km_user for the requesting user.
+        Create a new Know Me specific user for the requesting user.
 
         Returns:
-            A new ``KMUser`` instance.
+            :class:`.KMUser`:
+                A new Know Me user.
 
         Raises:
             ValidationError:
-                If the user making the request already has a km_user.
+                If the user making the request already has a Know Me
+                specific account.
         """
         if hasattr(self.request.user, 'km_user'):
             raise ValidationError(
-                code='duplicate_km_user',
-                detail=_('Users may not have more than one km_user.'))
+                _('Users may not have more than one Know Me account.'))
 
         return serializer.save(user=self.request.user)
+
+
+class MediaResourceDetailView(generics.RetrieveUpdateAPIView):
+    """
+    View for retrieving and updating a specific media resource.
+    """
+    permission_classes = (DRYPermissions,)
+    queryset = models.MediaResource.objects.all()
+    serializer_class = serializers.MediaResourceSerializer
 
 
 class ProfileGroupDetailView(generics.RetrieveUpdateAPIView):


### PR DESCRIPTION
The new endpoints mirror the functionality of the existing `/know-me/profiles/*` endpoints. All that was required was a little cleanup.

Closes #93