### PR TITLE
Add list content to profile item serializer

### DIFF
--- a/docs/API/know-me-profile.rst
+++ b/docs/API/know-me-profile.rst
@@ -93,14 +93,14 @@ KMUser Details
     :statuscode 400: The update failed. Check the response data for details.
 
 
---------------
+--------
 Profiles
---------------
+--------
 
 Profiles are the next step down in a know me user. They contain information targeted towards a profile of people.
 
 Profile List
-------------------
+------------
 
 The profile list endpoint allows for listing of a know me user's profiles as well as creation of new profiles.
 
@@ -138,7 +138,7 @@ The profile list endpoint allows for listing of a know me user's profiles as wel
     :statuscode 400: Invalid request. Check the response data for details.
 
 Profile Detail
---------------------
+--------------
 
 The profile detail endpoint allows for viewing and updating a profile's information.
 
@@ -179,14 +179,14 @@ The profile detail endpoint allows for viewing and updating a profile's informat
     :status 404: There is no profile with the given ``id`` accessible to the requesting user.
 
 
-------------
+--------------
 Profile Topics
-------------
+--------------
 
 Profile topics hold specific categories of information for a profile.
 
 Profile Topic List
-----------------
+------------------
 
 .. http:get:: /know-me/groups/(int:id)/topics/
 
@@ -227,7 +227,7 @@ Profile Topic List
     :status 404: There is no profile with the given ``id`` accessible to the requesting user.
 
 Profile Topic Detail
-------------------
+--------------------
 
 This endpoint allows for viewing and updating a specific profile topic's information.
 
@@ -288,9 +288,8 @@ This endpoint allows for listing the items in a profile topic and adding new ite
     :>jsonarr int id: The ID of the item.
     :>jsonarr string url: The URL of the item's detail view.
     :>jsonarr string name: The name of the item.
-    :>jsonarr string text: The text the item contains.
-    :>jsonarr int media_resource: The ID of the media resource attached to the profile item. Not present if the profile item doesn't have an attached media resource.
-    :>jsonarr object media_resource_info: The attached media resource's information, if present.
+    :>jsonarr object image_content: An object containing the item's image content. May be ``null``.
+    :>jsonarr object list_content: An object containing the item's list content. May be ``null`.
 
     :status 200: The profile item list was succesfully retrieved.
     :status 404: There is no profile topic with the given ``id`` accessible to the requesting user.
@@ -302,17 +301,16 @@ This endpoint allows for listing the items in a profile topic and adding new ite
     :param int id: The ID of the profile topic to create an item in.
 
     :<json string name: The name of the item.
-    :<json string text: The text the item will contain.
-    :<json int media_resource: *(Optional)* The ID of a media resource to attach to the profile item.
+    :<json object image_content: An object containing the item's image content. Mutually exclusive with ``list_content``.
+    :<json object list_content: An object containing the item's list content. Mutually exclusive with ``image_content``.
 
     :>header Location: The URL of the created item's detail view.
 
     :>json int id: The ID of the item.
     :>json string url: The URL of the item's detail view.
     :>json string name: The name of the item.
-    :>json string text: The text the item contains.
-    :>json int media_resource: The ID of the media resource attached to the profile item. Not present if the profile item doesn't have an attached media resource.
-    :>json object media_resource_info: The attached media resource's information, if present.
+    :>json object image_content: An object containing the item's image content. May be ``null``.
+    :>json object list_content: An object containing the item's list content. May be ``null`.
 
     :status 201: The profile item was succesfully created.
     :status 400: Invalid request. Check the response data for details.
@@ -332,9 +330,8 @@ This endpoint allows for retrieving and updating a specific profile item's infor
     :>json int id: The ID of the item.
     :>json string url: The URL of the item's detail view.
     :>json string name: The name of the item.
-    :>json string text: The text the item contains.
-    :>json int media_resource: The ID of the media resource attached to the profile item. Not present if the profile item doesn't have an attached media resource.
-    :>json object media_resource_info: The attached media resource's information, if present.
+    :>json object image_content: An object containing the item's image content. May be ``null``.
+    :>json object list_content: An object containing the item's list content. May be ``null`.
 
     :status 200: The profile item's information was succesfully retrieved.
     :status 404: There is no profile item with the given ``id`` accessible to the requesting user.
@@ -346,14 +343,14 @@ This endpoint allows for retrieving and updating a specific profile item's infor
     :param int id: The ID of the profile item to update.
 
     :<json string name: *(Optional)* A new name for the item.
-    :<json string text: *(Optional)* New text for the item.
+    :>json object image_content: *(Optional)* An object containing the item's image content. May be ``null``.
+    :>json object list_content: *(Optional)* An object containing the item's list content. May be ``null`.
 
     :>json int id: The ID of the item.
     :>json string url: The URL of the item's detail view.
     :>json string name: The name of the item.
-    :>json string text: The text the item contains.
-    :>json int media_resource: The ID of the media resource attached to the profile item. Not present if the profile item doesn't have an attached media resource.
-    :>json object media_resource_info: The attached media resource's information, if present.
+    :>json object image_content: An object containing the item's image content. May be ``null``.
+    :>json object list_content: An object containing the item's list content. May be ``null`.
 
     :status 200: The profile item's information was succesfully updated.
     :status 404: There is no profile item with the given ``id`` accessible to the requesting user.

--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -8,13 +8,19 @@ from .km_user_serializers import (                                  # noqa
     KMUserListSerializer,
 )
 
+from .media_resource_serializers import MediaResourceSerializer     # noqa
+
+from .profile_item_content_serializers import (                     # noqa
+    ImageContentSerializer,
+    ListContentSerializer,
+    ListEntrySerializer,
+)
+
+from .profile_item_serializers import ProfileItemSerializer         # noqa
+
 from .profile_serializers import (                                  # noqa
     ProfileDetailSerializer,
     ProfileListSerializer,
 )
-
-from .media_resource_serializers import MediaResourceSerializer     # noqa
-
-from .profile_item_serializers import ProfileItemSerializer         # noqa
 
 from .profile_topic_serializers import ProfileTopicSerializer       # noqa

--- a/km_api/know_me/serializers/profile_item_content_serializers.py
+++ b/km_api/know_me/serializers/profile_item_content_serializers.py
@@ -17,3 +17,24 @@ class ImageContentSerializer(serializers.ModelSerializer):
     class Meta(object):
         fields = ('id', 'description', 'image_resource', 'media_resource')
         model = models.ImageContent
+
+
+class ListEntrySerializer(serializers.ModelSerializer):
+    """
+    Serializer for entries in a profile item list.
+    """
+
+    class Meta(object):
+        fields = ('id', 'text')
+        model = models.ListEntry
+
+
+class ListContentSerializer(serializers.ModelSerializer):
+    """
+    Serializer for profile list content.
+    """
+    entries = ListEntrySerializer(many=True, read_only=True)
+
+    class Meta(object):
+        fields = ('id', 'entries')
+        model = models.ListContent

--- a/km_api/know_me/serializers/profile_item_serializers.py
+++ b/km_api/know_me/serializers/profile_item_serializers.py
@@ -1,11 +1,14 @@
 """Serializers for the ``ProfileItem`` model.
 """
 
+from django.utils.translation import ugettext_lazy as _
+
 from rest_framework import serializers
 
 from know_me import models
 from know_me.serializers.profile_item_content_serializers import (
-    ImageContentSerializer
+    ImageContentSerializer,
+    ListContentSerializer,
 )
 
 
@@ -14,11 +17,12 @@ class ProfileItemSerializer(serializers.HyperlinkedModelSerializer):
     Serializer for ``ProfileItem`` instances.
     """
     image_content = ImageContentSerializer(required=False)
+    list_content = ListContentSerializer(required=False)
     url = serializers.HyperlinkedIdentityField(
         view_name='know-me:profile-item-detail')
 
     class Meta:
-        fields = ('id', 'url', 'name', 'image_content')
+        fields = ('id', 'url', 'name', 'image_content', 'list_content')
         model = models.ProfileItem
 
     def create(self, data):
@@ -37,6 +41,7 @@ class ProfileItemSerializer(serializers.HyperlinkedModelSerializer):
                 A new profile item with the provided content.
         """
         image_content_data = data.pop('image_content', None)
+        list_content_data = data.pop('list_content', None)
 
         item = super(ProfileItemSerializer, self).create(data)
 
@@ -44,6 +49,11 @@ class ProfileItemSerializer(serializers.HyperlinkedModelSerializer):
             models.ImageContent.objects.create(
                 profile_item=item,
                 **image_content_data)
+
+        if list_content_data is not None:
+            models.ListContent.objects.create(
+                profile_item=item,
+                **list_content_data)
 
         return item
 
@@ -78,3 +88,43 @@ class ProfileItemSerializer(serializers.HyperlinkedModelSerializer):
             image_content_serializer.save()
 
         return item
+
+    def validate(self, data):
+        """
+        Validate the data provided to the serializer.
+
+        Args:
+            data (dict):
+                The data provided to the serializer.
+
+        Returns:
+            dict:
+                The validated data.
+
+        Raises:
+            :class:`serializers.ValidationError`:
+                If multiple content types are provided.
+        """
+        if 'image_content' in data and 'list_content' in data:
+            raise serializers.ValidationError(
+                _("Only one of 'image_content' and 'list_content' may be "
+                  "provided."))
+
+        # If we are creating a new instance, some content must be
+        # provided.
+        if not self.instance:
+            if 'image_content' not in data and 'list_content' not in data:
+                raise serializers.ValidationError(
+                    _("One of 'image_content' or 'list_content' must be "
+                      "provided."))
+
+        # If an existing instance is being edited, the type of content
+        # may not be changed.
+        else:
+            for attr in ('image_content', 'list_content'):
+                if attr in data and not hasattr(self.instance, attr):
+                    raise serializers.ValidationError(
+                        _('The type of content attached to a profile item may '
+                          'not change.'))
+
+        return data

--- a/km_api/know_me/tests/serializers/test_list_content_serializer.py
+++ b/km_api/know_me/tests/serializers/test_list_content_serializer.py
@@ -1,0 +1,39 @@
+from know_me import serializers
+
+
+def test_create(profile_item_factory):
+    """
+    Saving a serializer with valid data should create a new list content
+    instance.
+    """
+    item = profile_item_factory()
+    data = {}
+
+    serializer = serializers.ListContentSerializer(data=data)
+    assert serializer.is_valid()
+
+    content = serializer.save(profile_item=item)
+
+    assert content.profile_item == item
+
+
+def test_serialize(list_content_factory, list_entry_factory):
+    """
+    Test serializing list content.
+    """
+    content = list_content_factory()
+    list_entry_factory(list_content=content)
+    list_entry_factory(list_content=content)
+
+    serializer = serializers.ListContentSerializer(content)
+
+    entry_serializer = serializers.ListEntrySerializer(
+        content.entries.all(),
+        many=True)
+
+    expected = {
+        'id': content.id,
+        'entries': entry_serializer.data,
+    }
+
+    assert serializer.data == expected

--- a/km_api/know_me/tests/serializers/test_list_entry_serializer.py
+++ b/km_api/know_me/tests/serializers/test_list_entry_serializer.py
@@ -1,0 +1,55 @@
+from know_me import serializers
+
+
+def test_create(list_content_factory):
+    """
+    Saving a serializer with valid data should create a new list entry.
+    """
+    list_content = list_content_factory()
+    data = {
+        'text': 'Test list entry.',
+    }
+
+    serializer = serializers.ListEntrySerializer(data=data)
+    assert serializer.is_valid()
+
+    entry = serializer.save(list_content=list_content)
+
+    assert entry.list_content == list_content
+    assert entry.text == data['text']
+
+
+def test_serialize(list_entry_factory):
+    """
+    Test serializing a list entry.
+    """
+    entry = list_entry_factory()
+    serializer = serializers.ListEntrySerializer(entry)
+
+    expected = {
+        'id': entry.id,
+        'text': entry.text,
+    }
+
+    assert serializer.data == expected
+
+
+def test_update(list_entry_factory):
+    """
+    Saving a bound serializer should update the list entry the
+    serializer is bound to with the provided data.
+    """
+    entry = list_entry_factory(text='Old text.')
+    data = {
+        'text': 'New text.',
+    }
+
+    serializer = serializers.ListEntrySerializer(
+        entry,
+        data=data)
+    assert serializer.is_valid()
+
+    serializer.save()
+    entry.refresh_from_db()
+
+    assert entry.text == data['text']

--- a/km_api/know_me/tests/serializers/test_profile_item_serializer.py
+++ b/km_api/know_me/tests/serializers/test_profile_item_serializer.py
@@ -1,13 +1,10 @@
 from know_me import serializers
-from know_me.serializers.profile_item_content_serializers import (
-    ImageContentSerializer
-)
 
 
-def test_create(profile_topic_factory, serializer_context):
+def test_create_image_item(profile_topic_factory, serializer_context):
     """
-    Saving a serializer with valid data should create a new profile
-    item.
+    Saving a serializer with valid image content should create a new
+    profile item.
     """
     topic = profile_topic_factory()
 
@@ -35,13 +32,38 @@ def test_create(profile_topic_factory, serializer_context):
     assert content.description == data['image_content']['description']
 
 
+def test_create_list_item(profile_topic_factory, serializer_context):
+    """
+    Saving a serializer with valid list content should create a new
+    profile item.
+    """
+    topic = profile_topic_factory()
+
+    data = {
+        'name': 'List Profile Item',
+        'list_content': {},
+    }
+
+    serializer = serializers.ProfileItemSerializer(
+        context=serializer_context,
+        data=data)
+    assert serializer.is_valid()
+
+    item = serializer.save(topic=topic)
+
+    assert item.name == data['name']
+    assert item.topic == topic
+
+    assert item.list_content is not None
+
+
 def test_serialize_image_item(
         api_rf,
         image_content_factory,
         profile_item_factory,
         serializer_context):
     """
-    Test serializing a profile item.
+    Test serializing a profile item with image content.
     """
     item = profile_item_factory()
     image_content_factory(profile_item=item)
@@ -50,7 +72,7 @@ def test_serialize_image_item(
         item,
         context=serializer_context)
 
-    image_content_serializer = ImageContentSerializer(
+    image_content_serializer = serializers.ImageContentSerializer(
         item.image_content,
         context=serializer_context)
 
@@ -61,6 +83,38 @@ def test_serialize_image_item(
         'url': url_request.build_absolute_uri(),
         'name': item.name,
         'image_content': image_content_serializer.data,
+        'list_content': None,
+    }
+
+    assert serializer.data == expected
+
+
+def test_serialize_list_item(
+        api_rf,
+        list_content_factory,
+        profile_item_factory,
+        serializer_context):
+    """
+    Test serializing a profile item with list content.
+    """
+    item = profile_item_factory()
+    list_content_factory(profile_item=item)
+
+    serializer = serializers.ProfileItemSerializer(
+        item,
+        context=serializer_context)
+
+    list_content_serializer = serializers.ListContentSerializer(
+        item.list_content)
+
+    url_request = api_rf.get(item.get_absolute_url())
+
+    expected = {
+        'id': item.id,
+        'url': url_request.build_absolute_uri(),
+        'name': item.name,
+        'image_content': None,
+        'list_content': list_content_serializer.data,
     }
 
     assert serializer.data == expected
@@ -114,3 +168,66 @@ def test_update_image_content(image_content_factory, serializer_context):
     content.refresh_from_db()
 
     assert content.description == data['image_content']['description']
+
+
+def test_validate_content_type_change(
+        image_content_factory,
+        profile_item_factory,
+        serializer_context):
+    """
+    If a profile item was created with a certain content type and a
+    different type of content data was given to the serializer, the
+    serializer should not be valid.
+    """
+    item = profile_item_factory()
+    image_content_factory(profile_item=item)
+
+    data = {
+        'list_content': {},
+    }
+
+    serializer = serializers.ProfileItemSerializer(
+        item,
+        context=serializer_context,
+        data=data,
+        partial=True)
+
+    assert not serializer.is_valid()
+
+
+def test_validate_multiple_content_types(
+        profile_item_factory,
+        serializer_context):
+    """
+    If multiple types of content are provided to the serializer, it
+    should not be valid.
+    """
+    data = {
+        'name': 'Invalid Item',
+        'image_content': {
+            'description': 'Description...',
+        },
+        'list_content': {},
+    }
+
+    serializer = serializers.ProfileItemSerializer(
+        context=serializer_context,
+        data=data)
+
+    assert not serializer.is_valid()
+
+
+def test_validate_no_content(profile_item_factory, serializer_context):
+    """
+    If no content is provided for the profile item, the serializer
+    should not be valid.
+    """
+    data = {
+        'name': 'Invalid Item',
+    }
+
+    serializer = serializers.ProfileItemSerializer(
+        context=serializer_context,
+        data=data)
+
+    assert not serializer.is_valid()

--- a/km_api/know_me/tests/views/test_profile_item_detail_view.py
+++ b/km_api/know_me/tests/views/test_profile_item_detail_view.py
@@ -29,7 +29,7 @@ def test_get_item(api_rf, profile_item_factory):
     assert response.data == serializer.data
 
 
-def test_update(api_rf, profile_item_factory):
+def test_update(api_rf, image_content_factory, profile_item_factory):
     """
     Sending a PATCH request to the view with valid data should update
     the profile item with the given primary key.
@@ -43,40 +43,6 @@ def test_update(api_rf, profile_item_factory):
 
     data = {
         'name': 'New Name',
-    }
-
-    request = api_rf.patch(item.get_absolute_url(), data)
-    response = profile_item_detail_view(request, pk=item.pk)
-
-    assert response.status_code == status.HTTP_200_OK
-
-    item.refresh_from_db()
-    serializer = serializers.ProfileItemSerializer(
-        item,
-        context={'request': request})
-
-    assert response.data == serializer.data
-
-
-def test_update_with_media_resource(
-        api_rf,
-        media_resource_factory,
-        profile_item_factory):
-    """
-    Users should be able to attach a media resource to a profile item.
-
-    Regression test for #23
-    """
-    item = profile_item_factory()
-    topic = item.topic
-    profile = topic.profile
-    km_user = profile.km_user
-
-    api_rf.user = km_user.user
-
-    media_resource = media_resource_factory(km_user=km_user)
-    data = {
-        'media_resource': media_resource.pk,
     }
 
     request = api_rf.patch(item.get_absolute_url(), data)

--- a/km_api/know_me/tests/views/test_profile_item_list_view.py
+++ b/km_api/know_me/tests/views/test_profile_item_list_view.py
@@ -31,9 +31,10 @@ def test_create(api_rf, profile_topic_factory):
 
     data = {
         'name': 'Test Item',
+        'image_content': {},
     }
 
-    request = api_rf.post(topic.get_item_list_url(), data)
+    request = api_rf.post(topic.get_item_list_url(), data, format='json')
     response = profile_item_list_view(request, pk=topic.pk)
 
     assert response.status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
Profile items can now be created with list content or image content.
These options are mutually exclusive and cannot be changed once a
profile item is created.

Closes #100