### PR TITLE
Limit choices for media resource field.

### DIFF
--- a/km_api/know_me/serializers/fields.py
+++ b/km_api/know_me/serializers/fields.py
@@ -17,6 +17,25 @@ class MediaResourceField(serializers.RelatedField):
     """
     queryset = models.MediaResource.objects.all()
 
+    def get_queryset(self):
+        """
+        Limit the available resources using the serializer's context.
+
+        The queryset returned includes only the media resources owned by
+        the Know Me user given as context to the field.
+
+        Returns:
+            A queryset containing the media resources owned by the Know
+            Me user given as context to the field.
+        """
+        assert 'km_user' in self.context, (
+            "The serializer class '%s' requires 'km_user' to be provided as "
+            "context.") % self.__class__.__name__
+
+        queryset = super(MediaResourceField, self).get_queryset()
+
+        return queryset.filter(km_user=self.context['km_user'])
+
     def to_internal_value(self, data):
         """
         Retrieve the media resource with the provided ID.

--- a/km_api/know_me/tests/serializers/fields/test_media_resource_field.py
+++ b/km_api/know_me/tests/serializers/fields/test_media_resource_field.py
@@ -8,6 +8,35 @@ from know_me.serializers.media_resource_serializers import (
 )
 
 
+def test_get_queryset(km_user_factory, media_resource_factory):
+    """
+    The queryset should return all the items owned by the Know Me user
+    that is provided as context.
+    """
+    km_user = km_user_factory()
+    media_resource_factory(km_user=km_user)
+
+    media_resource_factory()
+
+    field = fields.MediaResourceField()
+    field.context = {
+        'km_user': km_user,
+    }
+
+    assert list(field.get_queryset()) == list(km_user.media_resources.all())
+
+
+def test_get_queryset_invalid_context():
+    """
+    If there is no 'km_user' in the field's context, an
+    ``AssertionError`` should be raised.
+    """
+    field = fields.MediaResourceField()
+
+    with pytest.raises(AssertionError):
+        field.get_queryset()
+
+
 def test_to_internal_value(media_resource_factory):
     """
     ``.to_internal_value()`` should return the media resource that has
@@ -15,17 +44,22 @@ def test_to_internal_value(media_resource_factory):
     """
     resource = media_resource_factory()
     field = fields.MediaResourceField()
+    field.context = {
+        'km_user': resource.km_user,
+    }
 
     assert field.to_internal_value(resource.id) == resource
 
 
-@pytest.mark.django_db
-def test_to_internal_value_non_existent():
+def test_to_internal_value_non_existent(km_user_factory):
     """
     If there is no media resource matching the provided ID, a
     ``ValidationError`` should be raised.
     """
     field = fields.MediaResourceField()
+    field.context = {
+        'km_user': km_user_factory(),
+    }
 
     with pytest.raises(ValidationError):
         field.to_internal_value(1)

--- a/km_api/know_me/tests/serializers/test_emergency_item_serializer.py
+++ b/km_api/know_me/tests/serializers/test_emergency_item_serializer.py
@@ -1,12 +1,14 @@
 from know_me import serializers
 
 
-def test_create(km_user_factory, media_resource_factory):
+def test_create(km_user_factory, media_resource_factory, serializer_context):
     """
     Saving a serializer with valid data should create a new emergency
     item.
     """
     km_user = km_user_factory()
+    serializer_context['km_user'] = km_user
+
     media_resource = media_resource_factory(km_user=km_user)
 
     data = {
@@ -15,7 +17,9 @@ def test_create(km_user_factory, media_resource_factory):
         'media_resource': media_resource.id,
     }
 
-    serializer = serializers.EmergencyItemSerializer(data=data)
+    serializer = serializers.EmergencyItemSerializer(
+        context=serializer_context,
+        data=data)
     assert serializer.is_valid()
 
     item = serializer.save(km_user=km_user)

--- a/km_api/know_me/tests/serializers/test_image_content_serializer.py
+++ b/km_api/know_me/tests/serializers/test_image_content_serializer.py
@@ -17,9 +17,12 @@ def test_create(
     ``ImageContent`` instance.
     """
     profile_item = profile_item_factory()
+    km_user = profile_item.topic.profile.km_user
 
-    image_resource = media_resource_factory(file=image)
-    media_resource = media_resource_factory()
+    serializer_context['km_user'] = km_user
+
+    image_resource = media_resource_factory(file=image, km_user=km_user)
+    media_resource = media_resource_factory(km_user=km_user)
 
     data = {
         'description': 'Test image content description.',
@@ -81,7 +84,11 @@ def test_update(
     content the serializer is bound to.
     """
     content = image_content_factory()
-    media_resource = media_resource_factory()
+    km_user = content.profile_item.topic.profile.km_user
+
+    serializer_context['km_user'] = km_user
+
+    media_resource = media_resource_factory(km_user=km_user)
 
     data = {
         'media_resource': media_resource.id,
@@ -100,11 +107,13 @@ def test_update(
 
 
 @pytest.mark.django_db
-def test_validate_invalid_resource_pk(serializer_context):
+def test_validate_invalid_resource_pk(km_user_factory, serializer_context):
     """
     If there is no media resource corresponding to the ID given to the
     serializer, the serializer should not be valid.
     """
+    serializer_context['km_user'] = km_user_factory()
+
     data = {
         'media_resource': 1,
     }


### PR DESCRIPTION
The queryset for the media resource field is now limited to the
resources owned by the Know Me user provided to the field as context.

Fixes #110