### PR TITLE
Fix coverage report for CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - AWS_BUCKET_NAME=elasticbeanstalk-us-east-1-656952694364
     - AWS_REGION=us-east-1
     - secure: "YARJiZmaMEM18Be1h8AUtB7xl9mK/Fcvm6FR8BTrQuNv9xRrLzlJ2Lhsl6+RpP/ifX72CUbXubwIX6h0KDgZriVE3SV/jQ0Ium6jQRbhnkTYE7xrE1FgTJIRhdDnNMD3Qhy7EEFROYkLXmiVf3wDA24twn7ez/8W/In6rIJkt48yGLxeGcPMq/7xCiXg0pyWOiibiZKzxHyFpqW37XZLsynjMTrX75FXEiVifmp6Pc0UVu7TbcOLQxS1by/HT/EbMYzLZJmJCwdP/Kq7rCfc4AMpacFJJQQuQH7GhQikdxd1priiqqtFYGeAKXRXKjTAr0iR4Pr95exo9GKysBox8mvfPFHJmwmBYrlhazIUkUeZOhj0IigOHjDMn/vNS/4vHI0ZDuecJvSHD8CmpmNcy8yPXHT/ywyQy/KlA10YkaFrFqFB5kLIqFZaARyJ9MDoP7bjkGU46ArJmcR14OIjAER+39S9jwaXtSFCmKn4+M7jyawe5Pm3O6meSHK6dGMj+rPPbH6VIpKZjxo4gT19EIt7tCy0l26pJDGNT3LtbTp48mSZTCnVmufFYuHgB1dEu77Jsxca++Non8rG1R9LegY/VH7h/CZMACsa/wsxiQM4U81x/Zg5HHOZanH7t/MjaxZUBanRXWA95N6JMfJL5bd/2ChCeHJT61IN8nDLhDU="
+    # Don't run tests in parallel. This fixes an issue with code coverage.
+    - PYTEST_ADDOPTS="-n0"
 
 install:
   - pip install --upgrade pip


### PR DESCRIPTION
When we set the default option for tests to run in parallel, it broke the coverage report from Travis CI.