### PR TITLE
Add filter backend for emergency items

### DIFF
--- a/km_api/know_me/filters.py
+++ b/km_api/know_me/filters.py
@@ -8,6 +8,35 @@ from dry_rest_permissions.generics import DRYPermissionFiltersBase
 from know_me import models
 
 
+class EmergencyItemFilterBackend(DRYPermissionFiltersBase):
+    """
+    Filter for listing emergency items for a user.
+    """
+
+    def filter_list_queryset(self, request, queryset, view):
+        """
+        Filter emergency items for a list action.
+
+        Args:
+            request:
+                The request being made.
+            queryset:
+                A queryset containing the objects to filter.
+            view:
+                The view being accessed.
+
+        Returns:
+            The provided queryset filtered to only include items owned
+            by the user specified in the provided views arguments.
+        """
+        km_user = get_object_or_404(
+            models.KMUser,
+            pk=view.kwargs.get('pk'),
+            user=request.user)
+
+        return queryset.filter(km_user=km_user)
+
+
 class KMUserFilterBackend(DRYPermissionFiltersBase):
     """
     Filter for listing ``KMUser`` instances.

--- a/km_api/know_me/tests/filters/test_emergency_item_filter_backend.py
+++ b/km_api/know_me/tests/filters/test_emergency_item_filter_backend.py
@@ -1,0 +1,86 @@
+from unittest import mock
+
+from django.http import Http404
+
+import pytest
+
+from know_me import filters, models
+
+
+def test_filter_list_by_km_user(
+        api_rf,
+        emergency_item_factory,
+        km_user_factory):
+    """
+    The filter backend should return emergency items owned by the Know
+    Me user whose ID is given in the URL.
+    """
+    km_user = km_user_factory()
+    emergency_item_factory(km_user=km_user)
+
+    emergency_item_factory()
+
+    api_rf.user = km_user.user
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk}
+
+    backend = filters.EmergencyItemFilterBackend()
+    result = backend.filter_list_queryset(
+        request,
+        models.EmergencyItem.objects.all(),
+        view)
+
+    expected = km_user.emergency_items.all()
+
+    assert list(result) == list(expected)
+
+
+def test_filter_list_non_existent_user(api_rf, emergency_item_factory):
+    """
+    If there is no Know Me user with the provided primary key, an
+    Http404 exception should be raised.
+    """
+    item = emergency_item_factory()
+    km_user = item.km_user
+
+    api_rf.user = km_user.user
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk + 1}
+
+    backend = filters.EmergencyItemFilterBackend()
+
+    with pytest.raises(Http404):
+        backend.filter_list_queryset(
+            request,
+            models.EmergencyItem.objects.all(),
+            view)
+
+
+def test_filter_list_inaccessible_user(
+        api_rf,
+        emergency_item_factory,
+        user_factory):
+    """
+    If the requesting user does not have access to the user who owns the
+    items, an Http404 exception should be raised.
+    """
+    item = emergency_item_factory()
+    km_user = item.km_user
+
+    api_rf.user = user_factory()
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk}
+
+    backend = filters.EmergencyItemFilterBackend()
+
+    with pytest.raises(Http404):
+        backend.filter_list_queryset(
+            request,
+            models.EmergencyItem.objects.all(),
+            view)

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -16,6 +16,7 @@ class EmergencyItemDetailView(generics.RetrieveUpdateDestroyAPIView):
     """
     View for updating and deleting a specific emergency item.
     """
+    filter_backends = (filters.EmergencyItemFilterBackend,)
     permission_classes = (DRYPermissions,)
     queryset = models.EmergencyItem.objects.all()
     serializer_class = serializers.EmergencyItemSerializer


### PR DESCRIPTION
This filter backend prevents users from accessing emergency items they don't have access to.

Closes #118