### PR TITLE
Restore missing profile serializer tests.

### DIFF
--- a/km_api/know_me/tests/serializers/test_profile_detail_serializer.py
+++ b/km_api/know_me/tests/serializers/test_profile_detail_serializer.py
@@ -1,0 +1,58 @@
+from know_me import serializers
+
+
+def test_serialize(
+        api_rf,
+        profile_factory,
+        profile_topic_factory,
+        serializer_context):
+    """
+    Test serializing a profile.
+    """
+    profile = profile_factory()
+    profile_topic_factory(profile=profile)
+    profile_topic_factory(profile=profile)
+
+    serializer = serializers.ProfileDetailSerializer(
+        profile,
+        context=serializer_context)
+    topic_serializer = serializers.ProfileTopicSerializer(
+        profile.topics,
+        context=serializer_context,
+        many=True)
+
+    url_request = api_rf.get(profile.get_absolute_url())
+    topic_list_request = api_rf.get(profile.get_topic_list_url())
+
+    expected = {
+        'id': profile.id,
+        'url': url_request.build_absolute_uri(),
+        'name': profile.name,
+        'is_default': profile.is_default,
+        'topics_url': topic_list_request.build_absolute_uri(),
+        'topics': topic_serializer.data,
+    }
+
+    assert serializer.data == expected
+
+
+def test_update(profile_factory):
+    """
+    Saving a bound serializer with valid data should update the profile
+    bound to the serializer.
+    """
+    profile = profile_factory(name='Old Profile')
+    data = {
+        'name': 'New Profile',
+    }
+
+    serializer = serializers.ProfileDetailSerializer(
+        profile,
+        data=data,
+        partial=True)
+    assert serializer.is_valid()
+
+    serializer.save()
+    profile.refresh_from_db()
+
+    assert profile.name == data['name']

--- a/km_api/know_me/tests/serializers/test_profile_list_serializer.py
+++ b/km_api/know_me/tests/serializers/test_profile_list_serializer.py
@@ -1,0 +1,46 @@
+from know_me import serializers
+
+
+def test_create(km_user_factory, serializer_context):
+    """
+    Saving a serializer instance with valid data should create a new
+    profile group.
+    """
+    km_user = km_user_factory()
+    data = {
+        'name': 'Profile',
+        'is_default': True,
+    }
+
+    serializer = serializers.ProfileListSerializer(
+        context=serializer_context,
+        data=data)
+    assert serializer.is_valid()
+
+    profile = serializer.save(km_user=km_user)
+
+    assert profile.name == data['name']
+    assert profile.km_user == km_user
+    assert profile.is_default == data['is_default']
+
+
+def test_serialize(api_rf, profile_factory, serializer_context):
+    """
+    Test serializing a profile.
+    """
+    profile = profile_factory()
+
+    serializer = serializers.ProfileListSerializer(
+        profile,
+        context=serializer_context)
+
+    url_request = api_rf.get(profile.get_absolute_url())
+
+    expected = {
+        'id': profile.id,
+        'url': url_request.build_absolute_uri(),
+        'name': profile.name,
+        'is_default': profile.is_default,
+    }
+
+    assert serializer.data == expected


### PR DESCRIPTION
Fixes #150

These were old test_profile_group_detail_serializer and test_profile_group_list_serializer tests, went through to change the names.