### PR TITLE
Add release tracking with Sentry

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,5 +3,8 @@ current_version = 0.5.1
 commit = True
 tag = False
 
-[bumpversion:file:docs/conf.py]
+[bumpversion:file:deploy/group_vars/amibuilder/main.yml]
+search = release: '{current_version}'
+replace = release: '{new_version}'
 
+[bumpversion:file:docs/conf.py]

--- a/deploy/group_vars/amibuilder/main.yml
+++ b/deploy/group_vars/amibuilder/main.yml
@@ -68,6 +68,7 @@ django_project_settings:
   RAVEN_CONFIG:
     dsn: "{{ vault_sentry_dsn }}"
     environment: "{{ sentry_environment }}"
+    release: '0.5.1'
 
 
 django_logging:


### PR DESCRIPTION
Closes #160

### Proposed Changes

This PR adds release tracking with Sentry. The version number is bumped automatically with the rest of our versioning logic.
