### PR TITLE
Add logic to handle pending user registration

### DIFF
--- a/km_api/account/models.py
+++ b/km_api/account/models.py
@@ -442,6 +442,28 @@ class User(PermissionsMixin, AbstractBaseUser):
             last_name='User',
             password=None)
 
+    def confirm_pending(self, first_name, last_name, password):
+        """
+        Confirm a pending user's account.
+
+        This marks the user as 'no longer pending' and merges the
+        existing information with the data provided when the user
+        registered.
+        """
+        assert self.is_pending, (
+            "'confirm_pending' may only be called on users with "
+            "'is_pending = True'.")
+
+        self.first_name = first_name
+        self.last_name = last_name
+        self.is_pending = False
+
+        self.set_password(password)
+
+        self.save()
+
+        logger.info('Confirmed pending user with email: %s', self.email)
+
     def get_full_name(self):
         """
         Get the user's full name.

--- a/km_api/account/tests/models/test_user_model.py
+++ b/km_api/account/tests/models/test_user_model.py
@@ -6,6 +6,43 @@ from account import models
 
 
 @pytest.mark.django_db
+def test_confirm_pending():
+    """
+    Confirming a pending user should update the user's information with
+    the data provided.
+    """
+    user = models.User.create_pending('test@example.com')
+
+    first_name = 'John'
+    last_name = 'Doe'
+    password = 'p455w0rd'
+
+    user.confirm_pending(
+        first_name=first_name,
+        last_name=last_name,
+        password=password)
+
+    user.refresh_from_db()
+
+    assert user.first_name == first_name
+    assert user.last_name == last_name
+    assert user.check_password(password)
+
+    assert not user.is_pending
+
+
+def test_confirm_pending_not_pending(user_factory):
+    """
+    If we attempt to confirm a user who is not pending, an error should
+    be raised.
+    """
+    user = user_factory()
+
+    with pytest.raises(AssertionError):
+        user.confirm_pending(first_name='foo', last_name='bar', password='baz')
+
+
+@pytest.mark.django_db
 def test_create():
     """
     Test creating a new user.

--- a/km_api/km_auth/serializers.py
+++ b/km_api/km_auth/serializers.py
@@ -79,6 +79,12 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
 
     class Meta:
         extra_kwargs = {
+            'email': {
+                # Override the default validation for email addresses.
+                # This allows us to validate email addresses of a
+                # pending user.
+                'validators': [],
+            },
             'password': {
                 'style': {'input_type': 'password'},
                 'write_only': True,
@@ -111,6 +117,24 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         confirmation.send_confirmation()
 
         return user
+
+    def validate_email(self, email):
+        """
+        Validate the provided email address.
+
+        Returns:
+            str:
+                The validated email address.
+
+        Raises:
+            ValidationError:
+                If that email exists and is verified already.
+        """
+        if EmailAddress.objects.filter(email=email, verified=True).exists():
+            raise serializers.ValidationError(
+                _('An account with that email address already exists.'))
+
+        return email
 
     def validate_password(self, password):
         """


### PR DESCRIPTION
Closes #137 

### Proposed Changes

This PR adds support for registering a pending user. If there is a user with `is_pending == True` whose email matches the email given when a user registers, then the pending user is updated using the provided information.