### PR TITLE
Add 'share' method for Know Me users.

### DIFF
--- a/km_api/account/tests/conftest.py
+++ b/km_api/account/tests/conftest.py
@@ -30,17 +30,6 @@ def email_confirmation_factory(db):
 
 
 @pytest.fixture
-def email_factory(db):
-    """
-    Get the factory used to create email addresses.
-
-    Returns:
-        The factory class used to create ``EmailAddress`` instances.
-    """
-    return factories.EmailFactory
-
-
-@pytest.fixture
 def password_reset_factory(db):
     """
     Get the factory used to create password resets.

--- a/km_api/conftest.py
+++ b/km_api/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from rest_framework.test import APIRequestFactory
 
+from account.factories import EmailFactory
 import factories
 
 
@@ -72,6 +73,17 @@ def api_rf():
         ``user`` attribute of the factory instance.
     """
     return UserAPIRequestFactory(user=AnonymousUser())
+
+
+@pytest.fixture
+def email_factory(db):
+    """
+    Get the factory used to create email addresses.
+
+    Returns:
+        The factory class used to create ``EmailAddress`` instances.
+    """
+    return EmailFactory
 
 
 @pytest.fixture

--- a/km_api/km_auth/tests/conftest.py
+++ b/km_api/km_auth/tests/conftest.py
@@ -1,4 +1,0 @@
-"""Fixtures for testing the ``km_auth`` module.
-"""
-
-from account.tests.conftest import email_factory    # noqa


### PR DESCRIPTION
Closes #131

### Proposed Changes

This PR adds a `share` method to the `KMUser` model. This method allows for sharing of a Know Me user's account.


### Todo

One issue that I see with this approach is the following
1. User invited by email
2. Account doesn't exist, so pending user created
3. Existing user changes their email address to the one used to create the invitation in step 1.

Now the pending user can't sign up because the email address is already in use. Admittedly this is a really niche issue that I don't expect to happen that often. Still, is this something we want to worry about?