### PR TITLE
Update KMUser filter backend to respect sharing

### DIFF
--- a/km_api/know_me/filters.py
+++ b/km_api/know_me/filters.py
@@ -1,6 +1,7 @@
 """Filter backends for the ``know_me`` module.
 """
 
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 
 from dry_rest_permissions.generics import DRYPermissionFiltersBase
@@ -83,7 +84,10 @@ class KMUserFilterBackend(DRYPermissionFiltersBase):
             A queryset containing the km_users accessible to the user
             making the request.
         """
-        return queryset.filter(user=request.user)
+        query = Q(user=request.user)
+        query |= Q(km_user_accessor__user_with_access=request.user)
+
+        return queryset.filter(query)
 
 
 class ListEntryFilterBackend(DRYPermissionFiltersBase):

--- a/km_api/know_me/tests/filters/test_km_user_filter_backend.py
+++ b/km_api/know_me/tests/filters/test_km_user_filter_backend.py
@@ -20,3 +20,33 @@ def test_filter_list_owner(api_rf, km_user_factory):
     expected = models.KMUser.objects.filter(user=km_user.user)
 
     assert list(filtered) == list(expected)
+
+
+def test_filter_list_shared(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory,
+        user_factory):
+    """
+    If there is a ``KMUserAccessor`` that gives the requesting user
+    access to a ``KMUser``, that Know Me user should be included in the
+    results.
+    """
+    km_user = km_user_factory()
+    user = user_factory()
+
+    km_user_accessor_factory(km_user=km_user, user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.get('/')
+
+    backend = filters.KMUserFilterBackend()
+    filtered = backend.filter_list_queryset(
+        request,
+        models.KMUser.objects.all(),
+        None)
+
+    expected = models.KMUser.objects.filter(
+        km_user_accessor__user_with_access=user)
+
+    assert list(filtered) == list(expected)


### PR DESCRIPTION
Addresses #173

### Proposed Changes

This PR updates the `KMUserFilterBackend` to also return `KMUser` instances that the requesting user has been invited to.

#### Todo

The one thing left to do here is determine the behavior for unaccepted invitations. My current thoughts are that we should exclude them from this list and have a separate request for a user to view their pending invitations.