### PR TITLE
Exclude unaccepted shares from KMUser list.

### DIFF
--- a/km_api/know_me/filters.py
+++ b/km_api/know_me/filters.py
@@ -84,8 +84,12 @@ class KMUserFilterBackend(DRYPermissionFiltersBase):
             A queryset containing the km_users accessible to the user
             making the request.
         """
-        query = Q(user=request.user)
-        query |= Q(km_user_accessor__user_with_access=request.user)
+        # Filter for shared profiles
+        query = Q(km_user_accessor__user_with_access=request.user)
+        query &= Q(km_user_accessor__accepted=True)
+
+        # Also include user owned by requesting user if they exist
+        query |= Q(user=request.user)
 
         return queryset.filter(query)
 


### PR DESCRIPTION
Fixes #182

If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.

### Proposed Changes

The list returned by `/know-me/users/` now does not include users where the `KMUserAccessor` is not marked as 'accepted'.