### PR TITLE
Serializer for KMUserAccessor Model

### DIFF
--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -5,6 +5,8 @@ from .emergency_contact_serializers import EmergencyContactSerializer   # noqa
 
 from .emergency_item_serializers import EmergencyItemSerializer         # noqa
 
+from .km_user_accessor_serializers import KMUserAccessorSerializer      # noqa
+
 from .km_user_serializers import (                                      # noqa
     KMUserDetailSerializer,
     KMUserListSerializer,

--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -1,6 +1,8 @@
 """Serializers for the ``KMUserAccessor`` model.
 """
 
+from django.utils.translation import ugettext_lazy as _
+
 from rest_framework import serializers
 
 from know_me import models
@@ -39,3 +41,26 @@ class KMUserAccessorSerializer(serializers.ModelSerializer):
         email = validated_data.pop('email')
 
         return km_user.share(email, **validated_data)
+
+    def validate_email(self, email):
+        """
+        Validate the provided email address.
+
+        Args:
+            email (str):
+                The email address to validate.
+
+        Returns:
+            str:
+                The validated email address.
+
+        Raises:
+            serializers.ValidationError:
+                If an accessor is being updated and the provided email
+                address does not match the accessor's current email.
+        """
+        if self.instance and email != self.instance.email:
+            raise serializers.ValidationError(
+                _('The email of an existing share may not be changed.'))
+
+        return email

--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -1,0 +1,25 @@
+"""Serializers for the ``KMUserAccessor`` model.
+"""
+
+from rest_framework import serializers
+
+from know_me import models
+
+
+class KMUserAccessorSerializer(serializers.ModelSerializer):
+    """
+    Serializer for multiple ``KMUserAccessor`` instances.
+    """
+    km_user = serializers.KMUserDetailSerializer(read_only=True)
+    user_with_access_email = serializers.EmailField(
+            source='user_with_access.email',
+            read_only=True)
+
+    class Meta:
+        fields = (
+            'accepted',
+            'can_write',
+            'has_private_profile_access',
+            'km_user',
+            'user_with_access_email',)
+        model = models.KMUserAccessor

--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -4,13 +4,14 @@
 from rest_framework import serializers
 
 from know_me import models
+from .km_user_serializers import KMUserDetailSerializer
 
 
 class KMUserAccessorSerializer(serializers.ModelSerializer):
     """
     Serializer for multiple ``KMUserAccessor`` instances.
     """
-    km_user = serializers.KMUserDetailSerializer(read_only=True)
+    km_user = KMUserDetailSerializer(read_only=True)
     user_with_access_email = serializers.EmailField(
             source='user_with_access.email',
             read_only=True)

--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -9,18 +9,33 @@ from .km_user_serializers import KMUserDetailSerializer
 
 class KMUserAccessorSerializer(serializers.ModelSerializer):
     """
-    Serializer for multiple ``KMUserAccessor`` instances.
+    Serializer for ``KMUserAccessor`` instances.
     """
     km_user = KMUserDetailSerializer(read_only=True)
-    user_with_access_email = serializers.EmailField(
-            source='user_with_access.email',
-            read_only=True)
 
     class Meta:
         fields = (
             'accepted',
             'can_write',
+            'email',
             'has_private_profile_access',
             'km_user',
-            'user_with_access_email',)
+        )
         model = models.KMUserAccessor
+        read_only_fields = ('accepted',)
+
+    def create(self, validated_data):
+        """
+        Create a new accessor for a Know Me user.
+
+        Args:
+            validated_data (dict):
+                The data to create the accessor from.
+
+        Returns:
+            The newly created ``KMUserAccessor`` instance.
+        """
+        km_user = validated_data.pop('km_user')
+        email = validated_data.pop('email')
+
+        return km_user.share(email, **validated_data)

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -1,4 +1,32 @@
+from unittest import mock
+
 from know_me import serializers
+
+
+def test_create(km_user_factory):
+    """
+    Saving the serializer should use the Know Me user's ``share`` method
+    to create a new accessor.
+    """
+    km_user = km_user_factory()
+    data = {
+        'can_write': True,
+        'email': 'test@example.com',
+        'has_private_profile_access': True,
+    }
+
+    serializer = serializers.KMUserAccessorSerializer(data=data)
+    assert serializer.is_valid()
+
+    with mock.patch.object(km_user, 'share', autospec=True) as mock_share:
+        serializer.save(km_user=km_user)
+
+    assert mock_share.call_count == 1
+    assert mock_share.call_args[0] == (data['email'],)
+    assert mock_share.call_args[1] == {
+        'can_write': data['can_write'],
+        'has_private_profile_access': data['has_private_profile_access'],
+    }
 
 
 def test_serialize(
@@ -13,6 +41,7 @@ def test_serialize(
     km_user = km_user_factory()
     user = user_factory()
     km_user_accessor = km_user_accessor_factory(
+        email=user.email,
         km_user=km_user,
         user_with_access=user)
 
@@ -27,9 +56,9 @@ def test_serialize(
     expected = {
         'accepted': False,
         'can_write': False,
+        'email': km_user_accessor.email,
         'has_private_profile_access': False,
         'km_user': km_user_serializer.data,
-        'user_with_access_email': user.email,
     }
 
     assert serializer.data == expected

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -1,0 +1,31 @@
+from know_me import serializers
+
+
+def test_serialize(
+        api_rf,
+        km_user_factory,
+        km_user_accessor_factory,
+        serializer_context,
+        user_factory):
+    """
+    Test serializing a km_user_accessor.
+    """
+    km_user = km_user_factory()
+    user = user_factory()
+    km_user_accessor = km_user_accessor_factory(
+        km_user=km_user,
+        user_with_access=user)
+
+    serializer = serializers.KMUserAccessorSerializer(
+        km_user_accessor,
+        context=serializer_context)
+
+    expected = {
+        'accepted': False,
+        'can_write': False,
+        'has_private_profile_access': False,
+        'km_user': km_user,
+        'user_with_access_email': user.email,
+    }
+
+    assert serializer.data == expected

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -20,11 +20,15 @@ def test_serialize(
         km_user_accessor,
         context=serializer_context)
 
+    km_user_serializer = serializers.KMUserDetailSerializer(
+        km_user,
+        context=serializer_context)
+
     expected = {
         'accepted': False,
         'can_write': False,
         'has_private_profile_access': False,
-        'km_user': km_user,
+        'km_user': km_user_serializer.data,
         'user_with_access_email': user.email,
     }
 

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -62,3 +62,19 @@ def test_serialize(
     }
 
     assert serializer.data == expected
+
+
+def test_validate_new_email(km_user_accessor_factory):
+    """
+    Trying to set a new email on an existing accessor should cause the
+    serializer to be invalid.
+    """
+    accessor = km_user_accessor_factory(email='old@example.com')
+    data = {
+        'email': 'new@example.com',
+    }
+
+    serializer = serializers.KMUserAccessorSerializer(accessor, data=data)
+
+    assert not serializer.is_valid()
+    assert set(serializer.errors.keys()) == {'email'}


### PR DESCRIPTION
Not ready for review.

Fixes #134 

Serializer for KMUser access model.


### Todo

- [x] pass test 
- [x] read only KMUserField 
- [x] add user_with_access_email field in serializer
- [x] create method should be overridden to use the KMUser.share method from #131 
- [x] override validate_email on the serializer to not allow changes to the email address unless a new instance is being created

