### PR TITLE
Allow accessors to be accepted

### DIFF
--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -24,7 +24,6 @@ class KMUserAccessorSerializer(serializers.ModelSerializer):
             'km_user',
         )
         model = models.KMUserAccessor
-        read_only_fields = ('accepted',)
 
     def create(self, validated_data):
         """
@@ -40,7 +39,43 @@ class KMUserAccessorSerializer(serializers.ModelSerializer):
         km_user = validated_data.pop('km_user')
         email = validated_data.pop('email')
 
+        # Remove 'accepted' from the arguments so it's not passed to the
+        # 'share' method.
+        validated_data.pop('accepted', None)
+
         return km_user.share(email, **validated_data)
+
+    def validate_accepted(self, accepted):
+        """
+        Validate the provided 'accepted' value.
+
+        Args:
+            accepted (boolean):
+                A boolean indicating if the accessor has been accepted.
+
+        Returns:
+            boolean:
+                The validated 'accepted' value.
+
+        Raises:
+            serializers.ValidationError:
+                If the user doesn't have permission to change the
+                'accepted' attribute.
+        """
+        accessor = self.instance
+
+        if not accessor and accepted:
+            raise serializers.ValidationError(
+                _("An accessor can't be marked as accepted until after it has "
+                  "been created."))
+        elif accessor \
+                and accessor.accepted != accepted \
+                and accessor.user_with_access != self.context['request'].user:
+            raise serializers.ValidationError(
+                _("Only the user granted access by the accessor may accept "
+                  "the accessor."))
+
+        return accepted
 
     def validate_email(self, email):
         """

--- a/km_api/know_me/tests/views/test_accessor_detail_view.py
+++ b/km_api/know_me/tests/views/test_accessor_detail_view.py
@@ -60,6 +60,20 @@ def test_get_accessor_other_user(
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+def test_get_accessor_shared(api_rf, km_user_accessor_factory, user_factory):
+    """
+    Users should be able to access an accessor that grants them access
+    to an account.
+    """
+    accessor = km_user_accessor_factory(user_with_access=user_factory())
+    api_rf.user = accessor.user_with_access
+
+    request = api_rf.get('/')
+    response = accessor_detail_view(request, pk=accessor.pk)
+
+    assert response.status_code == status.HTTP_200_OK
+
+
 def test_patch_accessor(api_rf, km_user_accessor_factory):
     """
     Sending a PATCH request to the view should update the accessor with

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -28,11 +28,10 @@ class AccessorDetailView(generics.RetrieveUpdateDestroyAPIView):
             A queryset containing the ``KMUserAccessor`` instances
             belonging to the requesting user.
         """
-        km_user = get_object_or_404(
-            models.KMUser,
-            user=self.request.user)
+        query = Q(km_user__user=self.request.user)
+        query |= Q(user_with_access=self.request.user)
 
-        return km_user.km_user_accessors.all()
+        return models.KMUserAccessor.objects.filter(query)
 
 
 class AccessorListView(generics.ListCreateAPIView):


### PR DESCRIPTION
Closes #197 

### Proposed Changes

This PR allows users to mark accessors granting them access to an account as "accepted".


### Todo

- [x] Give invited user access to accessor detail view
- [x] Allow invited user to change the `accepted` field of the accessor.
