### PR TITLE
Add detail URL to accessor serializer

### DIFF
--- a/docs/API/know-me-sharing.rst
+++ b/docs/API/know-me-sharing.rst
@@ -20,6 +20,7 @@ The accessor list view allows for retrieving existing accessors and creating new
 
     List the existing accessors for the requesting user.
 
+    :>jsonarr string url: The URL of the accessor's detail view.
     :>jsonarr boolean accepted: A boolean indicating if the invitation has been accepted by the invited user.
     :>jsonarr boolean can_write: A boolean indicating if the accessor grants the invited user write access to profiles.
     :>jsonarr string email: The email address used to invite the user.
@@ -36,6 +37,9 @@ The accessor list view allows for retrieving existing accessors and creating new
     :<json string email: The email address of the user to invite.
     :<json boolean has_private_profile_access: A boolean indicating if the invited user should have access to profiles marked as private.
 
+    :>header Location: The URL of the created accessor's detail view.
+
+    :>json string url: The URL of the accessor's detail view.
     :>json boolean accepted: A boolean indicating if the invitation has been accepted by the invited user.
     :>json boolean can_write: A boolean indicating if the accessor grants the invited user write access to profiles.
     :>json string email: The email address used to invite the user.
@@ -56,6 +60,7 @@ The accessor detail view allows for retrieving, updating, or deleting a specific
 
     :param int id: The ID of the accessor to retrieve.
 
+    :>json string url: The URL of the accessor's detail view.
     :>json boolean accepted: A boolean indicating if the invitation has been accepted by the invited user.
     :>json boolean can_write: A boolean indicating if the accessor grants the invited user write access to profiles.
     :>json string email: The email address used to invite the user.
@@ -97,6 +102,7 @@ the user the accessor grants access to.
 
     Get the pending accessors for the requesting user.
 
+    :>jsonarr string url: The URL of the accessor's detail view.
     :>jsonarr can_write accepted: A boolean indicating if the accessor has been accepted yet. This will be ``false`` for all elements in the list.
     :>jsonarr boolean can_write: A boolean indicating if the accessor grants the user write permission on the shared profiles.
     :>jsonarr string email: The email address used to invite the user.

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -618,6 +618,26 @@ class KMUserAccessor(mixins.IsAuthenticatedMixin, models.Model):
         """
         return 'Accessor for {user}'.format(user=self.km_user.name)
 
+    def get_absolute_url(self, request=None):
+        """
+        Get the URL of the instance's detail view.
+
+        Args:
+            request:
+                The request to use as context when constructing the URL.
+                Defaults to ``None``.
+
+        Returns:
+            The URL of the instance's detail view. If a request is
+            provided, a full URL including the protocol and domain will
+            be returned. Otherwise a path relative to the root of the
+            current domain is returned.
+        """
+        return reverse(
+            'know-me:accessor-detail',
+            kwargs={'pk': self.pk},
+            request=request)
+
 
 class ListContent(mixins.IsAuthenticatedMixin, models.Model):
     """

--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -14,9 +14,11 @@ class KMUserAccessorSerializer(serializers.ModelSerializer):
     Serializer for ``KMUserAccessor`` instances.
     """
     km_user = KMUserDetailSerializer(read_only=True)
+    url = serializers.SerializerMethodField()
 
     class Meta:
         fields = (
+            'url',
             'accepted',
             'can_write',
             'email',
@@ -44,6 +46,19 @@ class KMUserAccessorSerializer(serializers.ModelSerializer):
         validated_data.pop('accepted', None)
 
         return km_user.share(email, **validated_data)
+
+    def get_url(self, accessor):
+        """
+        Get the URL of the provided accessor's detail view.
+
+        Args:
+            accessor:
+                The accessor being serialized.
+
+        Returns:
+            The full URL of the accessor's detail view.
+        """
+        return accessor.get_absolute_url(self.context['request'])
 
     def validate_accepted(self, accepted):
         """

--- a/km_api/know_me/tests/models/test_km_user_accessor_model.py
+++ b/km_api/know_me/tests/models/test_km_user_accessor_model.py
@@ -1,3 +1,5 @@
+from rest_framework.reverse import reverse
+
 from know_me import models
 
 
@@ -14,6 +16,28 @@ def test_create(km_user_factory, user_factory):
         has_private_profile_access=False,
         km_user=km_user_factory(),
         user_with_access=user)
+
+
+def test_get_absolute_url(km_user_accessor_factory):
+    """
+    This method should return the URL of the accessor's detail view.
+    """
+    accessor = km_user_accessor_factory()
+    expected = reverse('know-me:accessor-detail', kwargs={'pk': accessor.pk})
+
+    assert accessor.get_absolute_url() == expected
+
+
+def test_get_absolute_url_with_request(api_rf, km_user_accessor_factory):
+    """
+    If a request is provided, the result should be a full URI.
+    """
+    accessor = km_user_accessor_factory()
+    absolute = reverse('know-me:accessor-detail', kwargs={'pk': accessor.pk})
+    request = api_rf.get(absolute)
+    expected = request.build_absolute_uri()
+
+    assert accessor.get_absolute_url(request) == expected
 
 
 def test_string_conversion(km_user_accessor_factory):

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -115,7 +115,10 @@ def test_serialize(
         km_user,
         context=serializer_context)
 
+    url = km_user_accessor.get_absolute_url(serializer_context['request'])
+
     expected = {
+        'url': url,
         'accepted': False,
         'can_write': False,
         'email': km_user_accessor.email,

--- a/km_api/know_me/tests/views/test_accessor_detail_view.py
+++ b/km_api/know_me/tests/views/test_accessor_detail_view.py
@@ -1,5 +1,4 @@
 from rest_framework import status
-from rest_framework.reverse import reverse
 
 from know_me import serializers, views
 
@@ -83,7 +82,7 @@ def test_get_accessor_unauthenticated(api_client, km_user_accessor_factory):
     """
     accessor = km_user_accessor_factory()
 
-    url = reverse('know-me:accessor-detail', kwargs={'pk': accessor.pk})
+    url = accessor.get_absolute_url()
     response = api_client.get(url)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
Closes #202

### Proposed Changes

This PR adds the URL of the accessor's detail view to the accessor serializer.