### PR TITLE
Trim down km_user info for accessor serializer.

### DIFF
--- a/km_api/know_me/serializers/km_user_accessor_serializers.py
+++ b/km_api/know_me/serializers/km_user_accessor_serializers.py
@@ -6,14 +6,14 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 from know_me import models
-from .km_user_serializers import KMUserDetailSerializer
+from .km_user_serializers import KMUserListSerializer
 
 
 class KMUserAccessorSerializer(serializers.ModelSerializer):
     """
     Serializer for ``KMUserAccessor`` instances.
     """
-    km_user = KMUserDetailSerializer(read_only=True)
+    km_user = KMUserListSerializer(read_only=True)
     url = serializers.SerializerMethodField()
 
     class Meta:

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -111,7 +111,7 @@ def test_serialize(
         km_user_accessor,
         context=serializer_context)
 
-    km_user_serializer = serializers.KMUserDetailSerializer(
+    km_user_serializer = serializers.KMUserListSerializer(
         km_user,
         context=serializer_context)
 


### PR DESCRIPTION
Closes #203

### Proposed Changes

The KMUserAccessorSerializer now only returns the information from the
KMUserListSerializer rather than the full KMUserDetailSerializer.
