### PR TITLE
Fix issue with filters not being applied.

### DIFF
--- a/km_api/know_me/filters.py
+++ b/km_api/know_me/filters.py
@@ -4,12 +4,12 @@
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 
-from dry_rest_permissions.generics import DRYPermissionFiltersBase
+from rest_framework import filters
 
 from know_me import models
 
 
-class KMUserAccessFilterBackend(DRYPermissionFiltersBase):
+class KMUserAccessFilterBackend(filters.BaseFilterBackend):
     """
     Filter for listing items owned by a Know Me user.
 
@@ -19,7 +19,7 @@ class KMUserAccessFilterBackend(DRYPermissionFiltersBase):
          user whose ID is provided in the request.
     """
 
-    def filter_list_queryset(self, request, queryset, view):
+    def filter_queryset(self, request, queryset, view):
         """
         Filter items for a list action.
 

--- a/km_api/know_me/tests/filters/test_km_user_access_filter_backend.py
+++ b/km_api/know_me/tests/filters/test_km_user_access_filter_backend.py
@@ -34,7 +34,7 @@ def test_filter_list_by_km_user(
     view.kwargs = {'pk': km_user.pk}
 
     backend = filters.KMUserAccessFilterBackend()
-    result = backend.filter_list_queryset(
+    result = backend.filter_queryset(
         request,
         models.EmergencyContact.objects.all(),
         view)
@@ -58,7 +58,7 @@ def test_filter_list_non_existent_user(api_rf, user_factory):
     backend = filters.KMUserAccessFilterBackend()
 
     with pytest.raises(Http404):
-        backend.filter_list_queryset(
+        backend.filter_queryset(
             request,
             models.EmergencyContact.objects.all(),
             view)
@@ -83,7 +83,7 @@ def test_filter_list_inaccessible_user(
     backend = filters.KMUserAccessFilterBackend()
 
     with pytest.raises(Http404):
-        backend.filter_list_queryset(
+        backend.filter_queryset(
             request,
             models.EmergencyContact.objects.all(),
             view)
@@ -114,7 +114,7 @@ def test_filter_list_shared(
     view.kwargs = {'pk': km_user.pk}
 
     backend = filters.KMUserAccessFilterBackend()
-    filtered = backend.filter_list_queryset(
+    filtered = backend.filter_queryset(
         request,
         models.EmergencyContact.objects.all(),
         view)
@@ -151,7 +151,7 @@ def test_filter_list_shared_not_accepted(
     backend = filters.KMUserAccessFilterBackend()
 
     with pytest.raises(Http404):
-        backend.filter_list_queryset(
+        backend.filter_queryset(
             request,
             models.EmergencyContact.objects.all(),
             view)


### PR DESCRIPTION
Fixes #224

### Proposed Changes

Use the default filter backend base provided by DRF instead of the one from `dry-rest-permissions`.