### PR TITLE
Make get_serializer_context safer

### DIFF
--- a/km_api/know_me/tests/views/test_profile_item_list_view.py
+++ b/km_api/know_me/tests/views/test_profile_item_list_view.py
@@ -64,6 +64,39 @@ def test_get_items(api_rf, profile_item_factory, profile_topic_factory):
     assert response.data == serializer.data
 
 
+def test_get_serializer_context(profile_topic_factory):
+    """
+    The serializer context should include the Know Me user who owns the
+    profile topic whose PK is passed to the view.
+    """
+    topic = profile_topic_factory()
+    km_user = topic.profile.km_user
+
+    view = views.ProfileItemListView()
+    view.format_kwarg = None
+    view.kwargs = {'pk': topic.pk}
+    view.request = None
+
+    context = view.get_serializer_context()
+
+    assert context['km_user'] == km_user
+
+
+def test_get_serializer_context_no_topic_pk(db):
+    """
+    If no primary key is given to the view, the serializer context
+    should use None for the Know Me user.
+    """
+    view = views.ProfileItemListView()
+    view.format_kwarg = None
+    view.kwargs = {}
+    view.request = None
+
+    context = view.get_serializer_context()
+
+    assert context['km_user'] is None
+
+
 def test_get_shared_items(
         api_rf,
         km_user_accessor_factory,

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -468,8 +468,12 @@ class ProfileItemListView(generics.ListCreateAPIView):
         """
         context = super().get_serializer_context()
 
-        context['km_user'] = models.KMUser.objects.get(
-            profile__topic__pk=self.kwargs.get('pk'))
+        pk = self.kwargs.get('pk', None)
+        if pk is None:
+            context['km_user'] = None
+        else:
+            context['km_user'] = models.KMUser.objects.get(
+                profile__topic__pk=pk)
 
         return context
 


### PR DESCRIPTION
Closes #219

The places where we override 'get_serializer_context' now include checks
for kwargs not existing due to the way the documentation is generated.

<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->