### PR TITLE
Add endpoints for managing media resource categories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ install:
 
 script:
   - flake8
-  - coverage run -m pytest km_api/
+  - COVERAGE_FILE=.coverage.unit coverage run -m pytest -m "not integration" km_api/
+  - COVERAGE_FILE=.coverage.int coverage run -m pytest -m "integration" km_api/
 
-after_success: codecov
+after_success:
+  - coverage combine
+  - codecov
 
 
 notifications:

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -798,7 +798,7 @@ class MediaResource(mixins.IsAuthenticatedMixin, models.Model):
         return self.km_user.user == request.user
 
 
-class MediaResourceCategory(models.Model):
+class MediaResourceCategory(mixins.IsAuthenticatedMixin, models.Model):
     """
     Category that a media resource can be placed in.
     """
@@ -826,6 +826,34 @@ class MediaResourceCategory(models.Model):
             The category's name.
         """
         return self.name
+
+    def has_object_read_permission(self, request):
+        """
+        Check read permissions on the instance for a given request.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            The permissions granted by the instance's parent Know Me
+            user.
+        """
+        return self.km_user.has_object_read_permission(request)
+
+    def has_object_write_permission(self, request):
+        """
+        Check write permissions on the instance for a given request.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            The permissions granted by the instance's parent Know Me
+            user.
+        """
+        return self.km_user.has_object_write_permission(request)
 
 
 class Profile(mixins.IsAuthenticatedMixin, models.Model):

--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -8,7 +8,10 @@ from .km_user_serializers import (                                      # noqa
     KMUserListSerializer,
 )
 
-from .media_resource_serializers import MediaResourceSerializer         # noqa
+from .media_resource_serializers import (                               # noqa
+    MediaResourceCategorySerializer,
+    MediaResourceSerializer,
+)
 
 from .profile_item_content_serializers import (                         # noqa
     ImageContentSerializer,

--- a/km_api/know_me/serializers/media_resource_serializers.py
+++ b/km_api/know_me/serializers/media_resource_serializers.py
@@ -7,6 +7,17 @@ from know_me import models
 from dry_rest_permissions.generics import DRYPermissionsField
 
 
+class MediaResourceCategorySerializer(serializers.ModelSerializer):
+    """
+    Serializer for ``MediaResourceCategory`` instances.
+    """
+
+    class Meta:
+        fields = ('id', 'km_user', 'name')
+        model = models.MediaResourceCategory
+        read_only_fields = ('km_user',)
+
+
 class MediaResourceSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for ``MediaResource`` instances.

--- a/km_api/know_me/tests/models/test_media_resource_category_model.py
+++ b/km_api/know_me/tests/models/test_media_resource_category_model.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from know_me import models
 
 
@@ -8,6 +10,54 @@ def test_create(km_user_factory):
     models.MediaResourceCategory.objects.create(
         km_user=km_user_factory(),
         name='Test Category')
+
+
+@mock.patch(
+    'know_me.models.KMUser.has_object_read_permission',
+    autospec=True,
+    return_value=True)
+def test_has_object_read_permission(
+        mock_parent_permission,
+        api_rf,
+        media_resource_category_factory):
+    """
+    The permissions on a media resource category should be dictated by
+    the permissions on the Know Me user who owns the category.
+    """
+    category = media_resource_category_factory()
+    request = api_rf.get('/')
+
+    mock_func = category.km_user.has_object_read_permission
+    expected = mock_func.return_value
+
+    assert category.has_object_read_permission(request) == expected
+
+    assert mock_func.call_count == 1
+    assert mock_func.call_args[0][1] == request
+
+
+@mock.patch(
+    'know_me.models.KMUser.has_object_write_permission',
+    autospec=True,
+    return_value=True)
+def test_has_object_write_permission(
+        mock_parent_permission,
+        api_rf,
+        media_resource_category_factory):
+    """
+    The permissions on a media resource category should be dictated by
+    the permissions on the Know Me user who owns the category.
+    """
+    category = media_resource_category_factory()
+    request = api_rf.get('/')
+
+    mock_func = category.km_user.has_object_write_permission
+    expected = mock_func.return_value
+
+    assert category.has_object_write_permission(request) == expected
+
+    assert mock_func.call_count == 1
+    assert mock_func.call_args[0][1] == request
 
 
 def test_string_conversion(media_resource_category_factory):

--- a/km_api/know_me/tests/serializers/test_media_resource_category_serializer.py
+++ b/km_api/know_me/tests/serializers/test_media_resource_category_serializer.py
@@ -1,0 +1,30 @@
+from know_me import serializers
+
+
+def test_serialize(media_resource_category_factory):
+    """
+    Test serializing a media resource category.
+    """
+    category = media_resource_category_factory()
+    serializer = serializers.MediaResourceCategorySerializer(category)
+
+    expected = {
+        'id': category.id,
+        'km_user': category.km_user.id,
+        'name': category.name,
+    }
+
+    assert serializer.data == expected
+
+
+def test_validate():
+    """
+    The serializer should validate any data providing all the required
+    fields.
+    """
+    data = {
+        'name': 'Test Category',
+    }
+    serializer = serializers.MediaResourceCategorySerializer(data=data)
+
+    assert serializer.is_valid()

--- a/km_api/know_me/tests/views/integration/test_media_resource_category_detail_view.py
+++ b/km_api/know_me/tests/views/integration/test_media_resource_category_detail_view.py
@@ -1,0 +1,76 @@
+import pytest
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from know_me import models, serializers
+
+
+@pytest.mark.integration
+def test_delete_media_resource_category(
+        api_client,
+        media_resource_category_factory):
+    """
+    Sending a DELETE request to the view should delete the category with
+    the given ID.
+    """
+    category = media_resource_category_factory()
+    api_client.force_authenticate(user=category.km_user.user)
+
+    url = reverse(
+        'know-me:media-resource-category-detail',
+        kwargs={'pk': category.pk})
+    response = api_client.delete(url)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert models.MediaResourceCategory.objects.count() == 0
+
+
+@pytest.mark.integration
+def test_retrieve_media_resource_category(
+        api_client,
+        media_resource_category_factory):
+    """
+    Sending a GET request to the view should return the details of the
+    category with the given ID.
+    """
+    category = media_resource_category_factory()
+    api_client.force_authenticate(user=category.km_user.user)
+
+    url = reverse(
+        'know-me:media-resource-category-detail',
+        kwargs={'pk': category.pk})
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    serializer = serializers.MediaResourceCategorySerializer(category)
+
+    assert response.data == serializer.data
+
+
+@pytest.mark.integration
+def test_update_media_resource_category(
+        api_client,
+        media_resource_category_factory):
+    """
+    Sending a PATCH request to the view should update the category with
+    the given ID.
+    """
+    category = media_resource_category_factory(name='Old Name')
+    api_client.force_authenticate(user=category.km_user.user)
+
+    data = {
+        'name': 'New Name',
+    }
+
+    url = reverse(
+        'know-me:media-resource-category-detail',
+        kwargs={'pk': category.pk})
+    response = api_client.patch(url, data)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    category.refresh_from_db()
+
+    assert category.name == data['name']

--- a/km_api/know_me/tests/views/integration/test_media_resource_category_list_view.py
+++ b/km_api/know_me/tests/views/integration/test_media_resource_category_list_view.py
@@ -1,0 +1,62 @@
+import pytest
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from know_me import serializers
+
+
+@pytest.mark.integration
+def test_create_media_resource_category(api_client, km_user_factory):
+    """
+    Sending a POST request to the view should create a new media
+    resource category.
+    """
+    km_user = km_user_factory()
+    api_client.force_authenticate(user=km_user.user)
+
+    data = {
+        'name': 'Test Category',
+    }
+
+    url = reverse(
+        'know-me:media-resource-category-list',
+        kwargs={'pk': km_user.pk})
+    response = api_client.post(url, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    serializer = serializers.MediaResourceCategorySerializer(
+        km_user.media_resource_categories.get())
+
+    assert response.data == serializer.data
+
+
+@pytest.mark.integration
+def test_list_media_resource_categories(
+        api_client,
+        km_user_factory,
+        media_resource_category_factory):
+    """
+    Sending a GET request to the view should list the media resource
+    categories accessible to that user.
+    """
+    km_user = km_user_factory()
+    api_client.force_authenticate(user=km_user.user)
+
+    media_resource_category_factory(km_user=km_user)
+    media_resource_category_factory(km_user=km_user)
+    media_resource_category_factory()
+
+    url = reverse(
+        'know-me:media-resource-category-list',
+        kwargs={'pk': km_user.pk})
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    serializer = serializers.MediaResourceCategorySerializer(
+        km_user.media_resource_categories.all(),
+        many=True)
+
+    assert response.data == serializer.data

--- a/km_api/know_me/tests/views/test_media_resource_category_detail_view.py
+++ b/km_api/know_me/tests/views/test_media_resource_category_detail_view.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from know_me import models, serializers, views
+
+
+@mock.patch(
+    'know_me.views.DRYPermissions.has_object_permission',
+    autospec=True)
+def test_check_object_permissions(mock_dry_permissions, api_rf):
+    """
+    The view should check the permissions on the model.
+    """
+    view = views.MediaResourceCategoryDetailView()
+
+    view.check_object_permissions(None, None)
+
+    assert mock_dry_permissions.call_count == 1
+
+
+def test_get_queryset(media_resource_category_factory):
+    """
+    The view should operate on all media resource categories.
+    """
+    media_resource_category_factory()
+    media_resource_category_factory()
+    media_resource_category_factory()
+
+    view = views.MediaResourceCategoryDetailView()
+    expected = models.MediaResourceCategory.objects.all()
+
+    assert list(view.get_queryset()) == list(expected)
+
+
+def test_get_serializer_class():
+    """
+    The view should use MediaResourceCategorySerializer as its
+    serializer class.
+    """
+    view = views.MediaResourceCategoryDetailView()
+    expected = serializers.MediaResourceCategorySerializer
+
+    assert view.get_serializer_class() == expected

--- a/km_api/know_me/tests/views/test_media_resource_category_list_view.py
+++ b/km_api/know_me/tests/views/test_media_resource_category_list_view.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+from know_me import models, serializers, views
+
+
+@mock.patch(
+    'know_me.views.DRYPermissions.has_permission',
+    autospec=True)
+@mock.patch(
+    'know_me.views.permissions.HasKMUserAccess.has_permission',
+    autospec=True)
+def test_check_permissions(mock_km_user_permission, mock_dry_permissions):
+    """
+    The view should check for model permissions as well as if the
+    requesting user has access to the parent Know Me user.
+    """
+    view = views.MediaResourceCategoryListView()
+
+    view.check_permissions(None)
+
+    assert mock_km_user_permission.call_count == 1
+    assert mock_dry_permissions.call_count == 1
+
+
+def test_get_queryset(media_resource_category_factory):
+    """
+    The view should act on all media resource categories.
+    """
+    media_resource_category_factory()
+    media_resource_category_factory()
+    media_resource_category_factory()
+
+    view = views.MediaResourceCategoryListView()
+    expected = models.MediaResourceCategory.objects.all()
+
+    assert list(view.get_queryset()) == list(expected)
+
+
+def test_get_serializer():
+    """
+    The serializer for the view should be
+    MediaResourceCategorySerializer.
+    """
+    view = views.MediaResourceCategoryListView()
+    expected = serializers.MediaResourceCategorySerializer
+
+    assert view.get_serializer_class() == expected
+
+
+@mock.patch(
+    'know_me.views.filters.KMUserAccessFilterBackend.filter_queryset',
+    autospec=True)
+def test_filter_queryset(mock_filter):
+    """
+    The queryset returned by the view should be passed through a filter
+    to restrict access.
+    """
+    view = views.MediaResourceCategoryListView()
+    view.request = None
+
+    queryset = models.MediaResourceCategory.objects.none()
+
+    view.filter_queryset(queryset)
+
+    assert mock_filter.call_count == 1
+
+
+def test_perform_create(km_user_factory):
+    """
+    The view should pass the Know Me user specified in the URL to the
+    serializer when creating a new category.
+    """
+    km_user = km_user_factory()
+    serializer = mock.Mock(name='Mock MediaResourceCategorySerializer')
+
+    view = views.MediaResourceCategoryListView()
+    view.kwargs = {'pk': km_user.pk}
+
+    assert view.perform_create(serializer) == serializer.save.return_value
+
+    assert serializer.save.call_count == 1
+    assert serializer.save.call_args[1] == {'km_user': km_user}

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -13,6 +13,11 @@ user_detail_endpoints = [
         name='km-user-detail'),
 
     url(
+        r'^media-resource-categories/$',
+        views.MediaResourceCategoryListView.as_view(),
+        name='media-resource-category-list'),
+
+    url(
         r'^media-resources/$',
         views.MediaResourceListView.as_view(),
         name='media-resource-list'),
@@ -38,4 +43,9 @@ urlpatterns = [
     url(r'^users/$', views.KMUserListView.as_view(), name='km-user-list'),
     url(r'^users/accessors/$', views.AccessorListView.as_view(), name='accessor-list'),                                             # noqa
     url(r'^users/(?P<pk>[0-9]+)/', include(user_detail_endpoints)),
+
+    url(
+        r'^media-resource-categories/(?P<pk>[0-9]+)/$',
+        views.MediaResourceCategoryDetailView.as_view(),
+        name='media-resource-category-detail'),
 ]

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -246,6 +246,57 @@ class ListEntryDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = serializers.ListEntrySerializer
 
 
+class MediaResourceCategoryDetailView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    delete:
+    Delete a specific media resource category.
+
+    get:
+    Retrieve information about a specific media resource category.
+
+    patch:
+    Partially update the information of a specific media resource
+    category.
+
+    put:
+    Update the information of a specific media resource category.
+    """
+    permission_classes = (DRYPermissions,)
+    queryset = models.MediaResourceCategory.objects.all()
+    serializer_class = serializers.MediaResourceCategorySerializer
+
+
+class MediaResourceCategoryListView(generics.ListCreateAPIView):
+    """
+    get:
+    Retrieve the list of media resource categories that belong to the
+    given Know Me user.
+
+    post:
+    Create a new media resource category for the given Know Me user.
+    """
+    filter_backends = (filters.KMUserAccessFilterBackend,)
+    permission_classes = (DRYPermissions, permissions.HasKMUserAccess)
+    queryset = models.MediaResourceCategory.objects.all()
+    serializer_class = serializers.MediaResourceCategorySerializer
+
+    def perform_create(self, serializer):
+        """
+        Create a new media resource category.
+
+        Args:
+            serializer:
+                An instance of the view's serializer class containing
+                the data passed to the view.
+
+        Returns:
+            The newly created media resource category.
+        """
+        km_user = models.KMUser.objects.get(pk=self.kwargs.get('pk'))
+
+        return serializer.save(km_user=km_user)
+
+
 class MediaResourceDetailView(generics.RetrieveUpdateAPIView):
     """
     get:


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #217 


### Proposed Changes

This PR adds two new endpoints for managing media resource categories. The first allows for listing and creating categories for a specific Know Me user. The second allows for fetching, updating, or deleting a specific category.

<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
