### PR TITLE
Fix strict KMUser permissions.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,9 @@ v0.8.0
 Breaking Changes
   * :issue:`253`: Massive rewrite of profile features. This is a backwards incompatible change that modifies endpoints, the data returned from profile endpoints, and requires a complete database wipe.
 
+Bug Fixes
+  * :issue:`261`: Fix permissions on ``KMUser`` instances not respecting sharing.
+
 Miscellaneous
   * :issue:`211`: Remove old "emergency" models.
 

--- a/km_api/know_me/profile/tests/serializers/test_list_entry_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_list_entry_serializer.py
@@ -6,6 +6,8 @@ def test_serialize(api_rf, list_entry_factory, serialized_time):
     Test serializing a list entry.
     """
     entry = list_entry_factory()
+
+    api_rf.user = entry.profile_item.topic.profile.km_user.user
     request = api_rf.get(entry.get_absolute_url())
 
     serializer = serializers.ListEntrySerializer(

--- a/km_api/know_me/profile/tests/serializers/test_media_resource_category_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_media_resource_category_serializer.py
@@ -6,6 +6,8 @@ def test_serialize(api_rf, media_resource_category_factory, serialized_time):
     Test serializing a media resource category.
     """
     category = media_resource_category_factory()
+
+    api_rf.user = category.km_user.user
     request = api_rf.get(category.get_absolute_url())
 
     serializer = serializers.MediaResourceCategorySerializer(

--- a/km_api/know_me/profile/tests/serializers/test_media_resource_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_media_resource_serializer.py
@@ -13,6 +13,8 @@ def test_serialize(
     resource = media_resource_factory(
         category=category,
         km_user=category.km_user)
+
+    api_rf.user = category.km_user.user
     request = api_rf.get(resource.get_absolute_url())
 
     serializer = serializers.MediaResourceSerializer(

--- a/km_api/know_me/profile/tests/serializers/test_profile_item_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_item_serializer.py
@@ -19,6 +19,8 @@ def test_serialize(
         image=image,
         media_resource=media_resource,
         topic__profile__km_user=media_resource.km_user)
+
+    api_rf.user = media_resource.km_user.user
     request = api_rf.get(item.get_absolute_url())
 
     serializer = serializers.ProfileItemSerializer(

--- a/km_api/know_me/profile/tests/serializers/test_profile_list_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_list_serializer.py
@@ -6,6 +6,8 @@ def test_serialize_profile(api_rf, profile_factory, serialized_time):
     Test serializing a profile.
     """
     profile = profile_factory()
+
+    api_rf.user = profile.km_user.user
     request = api_rf.get(profile.get_absolute_url())
 
     serializer = serializers.ProfileListSerializer(

--- a/km_api/know_me/profile/tests/serializers/test_profile_topic_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_topic_serializer.py
@@ -6,6 +6,8 @@ def test_serialize(api_rf, profile_topic_factory, serialized_time):
     Test serializing a profile topic.
     """
     topic = profile_topic_factory()
+
+    api_rf.user = topic.profile.km_user.user
     request = api_rf.get(topic.get_absolute_url())
 
     serializer = serializers.ProfileTopicSerializer(

--- a/km_api/know_me/tests/models/test_km_user_model.py
+++ b/km_api/know_me/tests/models/test_km_user_model.py
@@ -101,6 +101,40 @@ def test_has_object_read_permission_other(
     assert not km_user.has_object_read_permission(request)
 
 
+def test_has_object_read_permission_shared(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory):
+    """
+    The requesting user should be granted read access if there is an
+    accessor granting them access.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(accepted=True, km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    assert km_user.has_object_read_permission(request)
+
+
+def test_has_object_read_permission_shared_not_accepted(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory):
+    """
+    If the accessor granting access has not been accepted yet, access
+    should not be granted.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(accepted=False, km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    assert not km_user.has_object_read_permission(request)
+
+
 def test_has_object_read_permission_owner(api_rf, km_user_factory):
     """
     Users should have read access on their own km_user.
@@ -139,6 +173,65 @@ def test_has_object_write_permission_owner(api_rf, km_user_factory):
     request = api_rf.get('/')
 
     assert km_user.has_object_write_permission(request)
+
+
+def test_has_object_write_permission_shared(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory):
+    """
+    Users should be able to be granted write access through an accessor.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(
+        accepted=True,
+        can_write=True,
+        km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    assert km_user.has_object_write_permission(request)
+
+
+def test_has_object_write_permission_shared_no_write(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory):
+    """
+    Write access should not be granted from accessors that only grant
+    read access.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(
+        accepted=True,
+        can_write=False,
+        km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    assert not km_user.has_object_write_permission(request)
+
+
+def test_has_object_write_permission_shared_not_accepted(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory):
+    """
+    If the accessor has not been accepted, it should not grant write
+    access.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(
+        accepted=False,
+        can_write=True,
+        km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    assert not km_user.has_object_write_permission(request)
 
 
 def test_name(km_user_factory):


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #261 


### Proposed Changes

This PR fixes the overly strict permissions on `KMUser` instances. Users granted access through an accessor now have the proper access levels.
