### PR TITLE
Fix permissions for private profiles.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 
 Bug Fixes
   * :issue:`261`: Fix permissions on ``KMUser`` instances not respecting sharing.
+  * :issue:`262`: Fix access to private profiles being too open.
 
 Miscellaneous
   * :issue:`211`: Remove old "emergency" models.

--- a/km_api/know_me/profile/models.py
+++ b/km_api/know_me/profile/models.py
@@ -357,6 +357,11 @@ class Profile(mixins.IsAuthenticatedMixin, models.Model):
         """
         Check read permissions on the instance for a request.
 
+        If the profile is private, it requires the requesting user to be
+        granted admin permissions (or be the owner). This check is
+        already implemented in the write-permissions check of the parent
+        Know Me user, so we use it here.
+
         Args:
             request:
                 The request to check permissions for.
@@ -365,6 +370,9 @@ class Profile(mixins.IsAuthenticatedMixin, models.Model):
             A boolean indicating if the requesting user has read
             permissions on the instance.
         """
+        if self.is_private:
+            return self.km_user.has_object_write_permission(request)
+
         return self.km_user.has_object_read_permission(request)
 
     def has_object_write_permission(self, request):

--- a/km_api/know_me/profile/tests/models/test_profile_model.py
+++ b/km_api/know_me/profile/tests/models/test_profile_model.py
@@ -60,6 +60,29 @@ def test_has_object_read_permission(
 
 
 @mock.patch('know_me.models.KMUser.has_object_write_permission')
+def test_has_object_read_permission_private(
+        mock_parent_permission,
+        api_rf,
+        profile_factory):
+    """
+    Private profiles should delegate their read permission check to
+    their parent Know Me user's write permission check.
+
+    Using the 'write' permission is intentional. Access to private
+    profiles requires admin permissions, which is what write access to
+    the parent Know Me user requires.
+    """
+    profile = profile_factory(is_private=True)
+    request = api_rf.get('/')
+
+    expected = mock_parent_permission.return_value
+
+    assert profile.has_object_read_permission(request) == expected
+    assert mock_parent_permission.call_count == 1
+    assert mock_parent_permission.call_args[0] == (request,)
+
+
+@mock.patch('know_me.models.KMUser.has_object_write_permission')
 def test_has_object_write_permission(
         mock_parent_permission,
         api_rf,


### PR DESCRIPTION
Closes #262

Read access to private profiles now requires the requesting user to have
admin rights if they are a shared user.
