### PR TITLE
Fix private profile listing

### DIFF
--- a/km_api/know_me/profile/filters.py
+++ b/km_api/know_me/profile/filters.py
@@ -1,0 +1,44 @@
+from rest_framework import filters
+
+from know_me.models import KMUser
+
+
+class ProfileFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter for listing profile items.
+
+    This filter depends on ``KMUserAccessFilterBackend`` already being
+    applied.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Get the profiles accessible by the requesting user.
+
+        If the profile is marked as private, only the owner or account
+        admins can view it. Otherwise, the owner or any shared user can
+        access the profile.
+
+        Args:
+            request:
+                The request to filter for.
+            queryset:
+                The queryset to filter.
+            view:
+                The view being accessed.
+
+        Returns:
+            A queryset containing the profiles accessible to the
+            requesting user.
+        """
+        km_user = KMUser.objects.get(pk=view.kwargs.get('pk'))
+
+        if request.user == km_user.user:
+            return queryset
+
+        if km_user.km_user_accessors.filter(
+                is_admin=True,
+                user_with_access=request.user).exists():
+            return queryset
+
+        return queryset.filter(is_private=False)

--- a/km_api/know_me/profile/tests/filters/test_profile_filter_backend.py
+++ b/km_api/know_me/profile/tests/filters/test_profile_filter_backend.py
@@ -1,0 +1,98 @@
+from unittest import mock
+
+from know_me.profile import filters, models
+
+
+def test_filter_queryset_owner(api_rf, km_user_factory, profile_factory):
+    """
+    All profiles should be included for requests by the owner.
+    """
+    km_user = km_user_factory()
+    profile_factory(is_private=False, km_user=km_user)
+    profile_factory(is_private=True, km_user=km_user)
+
+    api_rf.user = km_user.user
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk}
+
+    backend = filters.ProfileFilterBackend()
+    result = backend.filter_queryset(
+        request,
+        models.Profile.objects.all(),
+        view)
+
+    expected = km_user.profiles.all()
+
+    assert list(result) == list(expected)
+
+
+def test_filter_queryset_shared_admin(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory,
+        profile_factory):
+    """
+    If the shared user is an admin, they should be able to see private
+    profiles.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(
+        is_accepted=True,
+        is_admin=True,
+        km_user=km_user)
+
+    profile_factory(is_private=False, km_user=km_user)
+    profile_factory(is_private=True, km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk}
+
+    backend = filters.ProfileFilterBackend()
+    result = backend.filter_queryset(
+        request,
+        models.Profile.objects.all(),
+        view)
+
+    expected = km_user.profiles.all()
+
+    assert list(result) == list(expected)
+
+
+def test_filter_queryset_shared_non_admin(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory,
+        profile_factory):
+    """
+    If the shared user does not have admin permissions, private profiles
+    should not be included in the results.
+    """
+    km_user = km_user_factory()
+    accessor = km_user_accessor_factory(
+        is_accepted=True,
+        is_admin=False,
+        km_user=km_user)
+
+    profile_factory(is_private=False, km_user=km_user)
+    profile_factory(is_private=True, km_user=km_user)
+
+    api_rf.user = accessor.user_with_access
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': km_user.pk}
+
+    backend = filters.ProfileFilterBackend()
+    result = backend.filter_queryset(
+        request,
+        models.Profile.objects.all(),
+        view)
+
+    expected = km_user.profiles.filter(is_private=False)
+
+    assert list(result) == list(expected)

--- a/km_api/know_me/profile/tests/views/test_profile_list_view.py
+++ b/km_api/know_me/profile/tests/views/test_profile_list_view.py
@@ -23,7 +23,9 @@ def test_check_permissions(mock_km_user_permission, mock_dry_permissions):
 
 
 @mock.patch('know_me.profile.views.KMUserAccessFilterBackend.filter_queryset')
-def test_filter_queryset(mock_filter):
+@mock.patch(
+    'know_me.profile.views.filters.ProfileFilterBackend.filter_queryset')
+def test_filter_queryset(mock_profile_filter, mock_access_filter):
     """
     The view should filter its queryset by passing it through the filter
     that restricts access to items based on the owner.
@@ -35,7 +37,8 @@ def test_filter_queryset(mock_filter):
 
     view.filter_queryset(queryset)
 
-    assert mock_filter.call_count == 1
+    assert mock_access_filter.call_count == 1
+    assert mock_profile_filter.call_count == 1
 
 
 def test_get_queryset(profile_factory):

--- a/km_api/know_me/profile/views.py
+++ b/km_api/know_me/profile/views.py
@@ -5,7 +5,7 @@ from rest_framework import generics
 from know_me.filters import KMUserAccessFilterBackend
 from know_me.models import KMUser
 from know_me.permissions import HasKMUserAccess
-from know_me.profile import models, permissions, serializers
+from know_me.profile import filters, models, permissions, serializers
 
 
 class ListEntryDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -220,7 +220,7 @@ class ProfileListView(generics.ListCreateAPIView):
     Only team leaders or the Know Me user themself can create a new
     profile.
     """
-    filter_backends = (KMUserAccessFilterBackend,)
+    filter_backends = (KMUserAccessFilterBackend, filters.ProfileFilterBackend)
     permission_classes = (DRYPermissions, HasKMUserAccess)
     queryset = models.Profile.objects.all()
     serializer_class = serializers.ProfileListSerializer


### PR DESCRIPTION
Fixes #262

Private profiles are no longer listed for users that don't actually
have permission to view that profile.