### PR TITLE
Add endpoint for listing and creating comments of a journal entry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Features
   * :issue:`246`: Create model for journal entries.
   * :issue:`247`: Add endpoint for listing and creating journal entries.
   * :issue:`248`: Create model for comments on journal entries.
+  * :issue:`249`: Add endpoint for listing and creating comments on journal entries.
 
 Bug Fixes
   * :issue:`254`: Fix Ansible creating duplicate crontab entries.

--- a/km_api/account/serializers.py
+++ b/km_api/account/serializers.py
@@ -27,6 +27,19 @@ class RegistrationSerializer(BaseRegistrationSerializer):
         model = get_user_model()
 
 
+class UserInfoSerializer(serializers.ModelSerializer):
+    """
+    Serializer for sharing the basic information of a user.
+
+    This serializer is a read-only serializer intended for use when we
+    need to display information about the user to another user.
+    """
+
+    class Meta:
+        fields = ('first_name', 'last_name')
+        model = get_user_model()
+
+
 class UserSerializer(serializers.ModelSerializer):
     """
     Serializer for ``User`` instances.

--- a/km_api/account/tests/serializers/test_user_info_serializer.py
+++ b/km_api/account/tests/serializers/test_user_info_serializer.py
@@ -1,0 +1,16 @@
+from account import serializers
+
+
+def test_serialize(user_factory):
+    """
+    Test serializing a user.
+    """
+    user = user_factory()
+    serializer = serializers.UserInfoSerializer(user)
+
+    expected = {
+        'first_name': user.first_name,
+        'last_name': user.last_name,
+    }
+
+    assert serializer.data == expected

--- a/km_api/know_me/journal/models.py
+++ b/km_api/know_me/journal/models.py
@@ -76,6 +76,17 @@ class Entry(mixins.IsAuthenticatedMixin, models.Model):
         """
         return reverse('know-me:journal:entry-detail', kwargs={'pk': self.pk})
 
+    def get_comments_url(self):
+        """
+        Get the URL of the instance's comment list view.
+
+        Returns:
+            The absolute URL of the instance's comment list view.
+        """
+        return reverse(
+            'know-me:journal:entry-comment-list',
+            kwargs={'pk': self.pk})
+
     def has_object_read_permission(self, request):
         """
         Check read permissions on the instance for a request.
@@ -188,3 +199,15 @@ class EntryComment(mixins.IsAuthenticatedMixin, models.Model):
             permissions on the instance.
         """
         return request.user == self.user
+
+    def has_object_write_permission(self, request):
+        """
+        Check write permissions on the instance for a request.
+
+        No one is granted blanket write permissions. More granular
+        permissions are handled by the 'destroy' and 'update' checks.
+
+        Returns:
+            ``False``
+        """
+        return False

--- a/km_api/know_me/journal/permissions.py
+++ b/km_api/know_me/journal/permissions.py
@@ -1,0 +1,33 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework import permissions
+
+from know_me.journal import models
+
+
+class HasEntryCommentListPermissions(permissions.BasePermission):
+    """
+    Permission for checking if a user has access to the comments of a
+    journal entry.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Determine if the requesting user has access to the view.
+
+        Anyone with read access to a journal entry should be able to
+        comment on it.
+
+        Args:
+            request:
+                The request being made.
+            view:
+                The view being accessed.
+
+        Returns:
+            A boolean inidicating if the requesting user should be
+            granted access to the view.
+        """
+        entry = get_object_or_404(models.Entry, pk=view.kwargs.get('pk'))
+
+        return entry.has_object_read_permission(request)

--- a/km_api/know_me/journal/serializers.py
+++ b/km_api/know_me/journal/serializers.py
@@ -2,19 +2,44 @@ from dry_rest_permissions.generics import DRYPermissionsField
 
 from rest_framework import serializers
 
+from account.serializers import UserInfoSerializer
 from know_me.journal import models
 
 
-class EntryListSerializer(serializers.ModelSerializer):
+class EntryCommentSerializer(serializers.ModelSerializer):
     """
-    Serializer for a list of journal entries.
+    Serializer for comments on journal entries.
     """
+    permissions = DRYPermissionsField()
+    user = UserInfoSerializer(read_only=True)
 
     class Meta:
         fields = (
             'id',
             'created_at',
             'updated_at',
+            'permissions',
+            'text',
+            'user')
+        model = models.EntryComment
+
+
+class EntryListSerializer(serializers.HyperlinkedModelSerializer):
+    """
+    Serializer for a list of journal entries.
+    """
+    comments_url = serializers.HyperlinkedIdentityField(
+        view_name='know-me:journal:entry-comment-list')
+    url = serializers.HyperlinkedIdentityField(
+        view_name='know-me:journal:entry-detail')
+
+    class Meta:
+        fields = (
+            'id',
+            'url',
+            'created_at',
+            'updated_at',
+            'comments_url',
             'km_user_id')
         model = models.Entry
 
@@ -23,7 +48,11 @@ class EntryDetailSerializer(EntryListSerializer):
     """
     Serializer for a single journal entry.
     """
+    comments = EntryCommentSerializer(many=True, read_only=True)
     permissions = DRYPermissionsField()
 
     class Meta(EntryListSerializer.Meta):
-        fields = EntryListSerializer.Meta.fields + ('permissions', 'text')
+        fields = EntryListSerializer.Meta.fields + (
+            'comments',
+            'permissions',
+            'text')

--- a/km_api/know_me/journal/tests/integration/test_entry_comment_list_view.py
+++ b/km_api/know_me/journal/tests/integration/test_entry_comment_list_view.py
@@ -1,0 +1,68 @@
+import pytest
+
+from rest_framework import status
+
+from know_me.journal import serializers
+
+
+@pytest.mark.integration
+def test_get_comment_list(
+        api_client,
+        api_rf,
+        entry_comment_factory,
+        entry_factory):
+    """
+    Sending a GET request to the view should return a list of the
+    comments attached to the specified journal entry.
+    """
+    entry = entry_factory()
+    user = entry.km_user.user
+
+    entry_comment_factory(entry=entry)
+    entry_comment_factory(entry=entry)
+    entry_comment_factory()
+
+    api_client.force_authenticate(user=user)
+    api_rf.user = user
+
+    url = entry.get_comments_url()
+    request = api_rf.get(url)
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    serializer = serializers.EntryCommentSerializer(
+        entry.comments.all(),
+        context={'request': request},
+        many=True)
+
+    assert response.data == serializer.data
+
+
+@pytest.mark.integration
+def test_post_new_comment(api_client, api_rf, entry_factory):
+    """
+    Sending a POST request to the view should create a new comment on
+    the specified journal entry.
+    """
+    entry = entry_factory()
+    user = entry.km_user.user
+
+    api_client.force_authenticate(user=user)
+    api_rf.user = user
+
+    data = {
+        'text': 'My comment text.',
+    }
+
+    url = entry.get_comments_url()
+    request = api_rf.post(url, data)
+    response = api_client.post(url, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    serializer = serializers.EntryCommentSerializer(
+        entry.comments.get(),
+        context={'request': request})
+
+    assert response.data == serializer.data

--- a/km_api/know_me/journal/tests/models/test_entry_comment_model.py
+++ b/km_api/know_me/journal/tests/models/test_entry_comment_model.py
@@ -81,3 +81,12 @@ def test_has_object_update_permission_other(api_rf, entry_comment_factory):
     request = api_rf.get('/')
 
     assert not comment.has_object_update_permission(request)
+
+
+def test_has_object_write_permission(entry_comment_factory):
+    """
+    No one should have write permission on a comment.
+    """
+    comment = entry_comment_factory()
+
+    assert not comment.has_object_write_permission(None)

--- a/km_api/know_me/journal/tests/models/test_entry_model.py
+++ b/km_api/know_me/journal/tests/models/test_entry_model.py
@@ -28,6 +28,19 @@ def test_get_absolute_url(entry_factory):
     assert entry.get_absolute_url() == expected
 
 
+def test_get_comments_url(entry_factory):
+    """
+    This method should return the URL of the instance's comment list
+    view.
+    """
+    entry = entry_factory()
+    expected = reverse(
+        'know-me:journal:entry-comment-list',
+        kwargs={'pk': entry.pk})
+
+    assert entry.get_comments_url() == expected
+
+
 @mock.patch('know_me.models.KMUser.has_object_read_permission')
 def test_has_object_read_permission(
         mock_parent_permission,

--- a/km_api/know_me/journal/tests/permissions/test_has_entry_comment_list_permissions.py
+++ b/km_api/know_me/journal/tests/permissions/test_has_entry_comment_list_permissions.py
@@ -1,0 +1,57 @@
+from unittest import mock
+
+from django.http import Http404
+
+import pytest
+
+from rest_framework.permissions import SAFE_METHODS
+
+from know_me.journal import permissions
+
+
+UNSAFE_METHODS = ("DELETE", "PATCH", "POST", "PUT")
+ALL_METHODS = SAFE_METHODS + UNSAFE_METHODS
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+@mock.patch(
+    'know_me.journal.permissions.models.Entry.has_object_read_permission')
+def test_has_permission(
+        mock_read_permission,
+        api_rf,
+        method,
+        entry_factory):
+    """
+    The permission check should be delegated to the entry whose comments
+    are being listed.
+    """
+    entry = entry_factory()
+
+    api_rf.user = entry.km_user.user
+    request = api_rf.generic(method, '/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': entry.pk}
+
+    permission = permissions.HasEntryCommentListPermissions()
+    perm_func = mock_read_permission
+
+    assert permission.has_permission(request, view) == perm_func.return_value
+    assert perm_func.call_count == 1
+    assert perm_func.call_args[0] == (request,)
+
+
+def test_has_permission_nonexistent_entry(api_rf, db):
+    """
+    If there is no entry with the given ID, the permission check should
+    raise an Http404 error.
+    """
+    request = api_rf.get('/')
+
+    view = mock.Mock(name='Mock View')
+    view.kwargs = {'pk': 1}
+
+    permission = permissions.HasEntryCommentListPermissions()
+
+    with pytest.raises(Http404):
+        permission.has_permission(request, view)

--- a/km_api/know_me/journal/tests/serializers/test_entry_comment_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_entry_comment_serializer.py
@@ -1,0 +1,46 @@
+from account.serializers import UserInfoSerializer
+from know_me.journal import serializers
+
+
+def test_serialize(api_rf, entry_comment_factory, serialized_time):
+    """
+    Test serializing an entry comment.
+    """
+    comment = entry_comment_factory()
+    api_rf.user = comment.user
+    request = api_rf.get('/')
+
+    serializer = serializers.EntryCommentSerializer(
+        comment,
+        context={'request': request})
+    user_serializer = UserInfoSerializer(
+        comment.user,
+        context={'request': request})
+
+    expected = {
+        'id': comment.id,
+        'created_at': serialized_time(comment.created_at),
+        'updated_at': serialized_time(comment.updated_at),
+        'permissions': {
+            'destroy': comment.has_object_destroy_permission(request),
+            'read': comment.has_object_read_permission(request),
+            'update': comment.has_object_update_permission(request),
+            'write': comment.has_object_write_permission(request),
+        },
+        'text': comment.text,
+        'user': user_serializer.data,
+    }
+
+    assert serializer.data == expected
+
+
+def test_validate():
+    """
+    Test validating the content required to create a new comment.
+    """
+    data = {
+        'text': 'My sample comment text.',
+    }
+    serializer = serializers.EntryCommentSerializer(data=data)
+
+    assert serializer.is_valid()

--- a/km_api/know_me/journal/tests/serializers/test_entry_detail_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_entry_detail_serializer.py
@@ -1,22 +1,30 @@
 from know_me.journal import serializers
 
 
-def test_serialize(api_rf, entry_factory):
+def test_serialize(api_rf, entry_comment_factory, entry_factory):
     """
     Test serializing a journal entry.
     """
     entry = entry_factory()
     api_rf.user = entry.km_user.user
-    request = api_rf.get('/')
+    request = api_rf.get(entry.get_absolute_url())
+
+    entry_comment_factory(entry=entry)
+    entry_comment_factory(entry=entry)
 
     serializer = serializers.EntryDetailSerializer(
         entry,
         context={'request': request})
+    comment_serializer = serializers.EntryCommentSerializer(
+        entry.comments.all(),
+        context={'request': request},
+        many=True)
     list_serializer = serializers.EntryListSerializer(
         entry,
         context={'request': request})
 
     additional = {
+        'comments': comment_serializer.data,
         'permissions': {
             'read': entry.has_object_read_permission(request),
             'write': entry.has_object_write_permission(request),

--- a/km_api/know_me/journal/tests/serializers/test_entry_list_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_entry_list_serializer.py
@@ -6,16 +6,20 @@ def test_serialize(api_rf, entry_factory, serialized_time):
     Test serializing a journal entry.
     """
     entry = entry_factory()
-    request = api_rf.get('/')
+    request = api_rf.get(entry.get_absolute_url())
 
     serializer = serializers.EntryListSerializer(
         entry,
         context={'request': request})
 
+    comments_url = api_rf.get(entry.get_comments_url()).build_absolute_uri()
+
     expected = {
         'id': entry.id,
+        'url': request.build_absolute_uri(),
         'created_at': serialized_time(entry.created_at),
         'updated_at': serialized_time(entry.updated_at),
+        'comments_url': comments_url,
         'km_user_id': entry.km_user.id,
     }
 

--- a/km_api/know_me/journal/tests/views/test_entry_comment_list_view.py
+++ b/km_api/know_me/journal/tests/views/test_entry_comment_list_view.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+from know_me.journal import serializers, views
+
+
+@mock.patch('know_me.journal.views.DRYPermissions.has_permission')
+@mock.patch('know_me.journal.views.permissions.HasEntryCommentListPermissions.has_permission')  # noqa
+def test_check_permissions(mock_list_permissions, mock_dry_permissions):
+    """
+    The view should use the appropriate permissions checks.
+    """
+    view = views.EntryCommentListView()
+
+    view.check_permissions(None)
+
+    assert mock_dry_permissions.call_count == 1
+    assert mock_list_permissions.call_count == 1
+
+
+def test_get_queryset(entry_comment_factory, entry_factory):
+    """
+    The view should operate on the comments that belong to the journal
+    entry specified in the URL.
+    """
+    entry = entry_factory()
+    entry_comment_factory(entry=entry)
+    entry_comment_factory()
+
+    view = views.EntryCommentListView()
+    view.kwargs = {'pk': entry.pk}
+
+    assert list(view.get_queryset()) == list(entry.comments.all())
+
+
+def test_get_serializer_class():
+    """
+    The view should use the serializer for entry comments.
+    """
+    view = views.EntryCommentListView()
+    expected = serializers.EntryCommentSerializer
+
+    assert view.get_serializer_class() == expected
+
+
+def test_perform_create(api_rf, entry_factory, user_factory):
+    """
+    Creating a comment should attach it to the journal entry specified
+    in the URL.
+    """
+    entry = entry_factory()
+    user = user_factory()
+    api_rf.user = user
+
+    view = views.EntryCommentListView()
+    view.kwargs = {'pk': entry.pk}
+    view.request = api_rf.get('/')
+
+    serializer = mock.Mock(name='Mock EntryCommentSerializer')
+
+    result = view.perform_create(serializer)
+
+    assert result == serializer.save.return_value
+    assert serializer.save.call_count == 1
+    assert serializer.save.call_args[1] == {
+        'entry': entry,
+        'user': user,
+    }

--- a/km_api/know_me/journal/urls.py
+++ b/km_api/know_me/journal/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
         name='entry-detail'),
 
     url(
+        r'^journal-entries/(?P<pk>[0-9]+)/comments/$',
+        views.EntryCommentListView.as_view(),
+        name='entry-comment-list'),
+
+    url(
         r'^users/(?P<pk>[0-9]+)/journal-entries/$',
         views.EntryListView.as_view(),
         name='entry-list'),


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #249 


### Proposed Changes

This PR adds an endpoint for listing the comments of a journal entry as well as creating a new comment. To assist in this process, we also created a new user serializer that only returns non-sensitive information about the user. We can use this new serializer anywhere we need to display information about one user to another user.
