### PR TITLE
Return URLs in Know Me user list endpoint.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Features
   * :issue:`247`: Add endpoint for listing and creating journal entries.
   * :issue:`248`: Create model for comments on journal entries.
   * :issue:`249`: Add endpoint for listing and creating comments on journal entries.
+  * :issue:`276`: Return URLs in Know Me user list rather than only from the detail endpoint.
 
 Bug Fixes
   * :issue:`254`: Fix Ansible creating duplicate crontab entries.

--- a/km_api/know_me/serializers.py
+++ b/km_api/know_me/serializers.py
@@ -3,32 +3,48 @@
 
 from django.utils.translation import ugettext_lazy as _
 
+from dry_rest_permissions.generics import DRYPermissionsField
+
 from rest_framework import serializers
 
 from know_me import models
 from know_me.profile.serializers import ProfileListSerializer
 
 
-EXTRA_FIELD_KWARGS = {
-    'image': {
-        'help_text': 'An image that represents the Know Me user.',
-    },
-    'quote': {
-        'help_text': "A quote for the Know Me user to introduce themself.",
-    },
-}
-
-
 class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for multiple ``KMUser`` instances.
     """
+    media_resource_categories_url = serializers.HyperlinkedIdentityField(
+        view_name='know-me:profile:media-resource-category-list')
+    media_resources_url = serializers.HyperlinkedIdentityField(
+        view_name='know-me:profile:media-resource-list')
+    profiles_url = serializers.HyperlinkedIdentityField(
+        view_name='know-me:profile:profile-list')
     url = serializers.HyperlinkedIdentityField(
         view_name='know-me:km-user-detail')
 
     class Meta:
-        extra_kwargs = EXTRA_FIELD_KWARGS
-        fields = ('id', 'url', 'name', 'image', 'quote')
+        extra_kwargs = {
+            'image': {
+                'help_text': 'An image that represents the Know Me user.',
+            },
+            'quote': {
+                'help_text': ("A quote for the Know Me user to introduce "
+                              "themself."),
+            },
+        }
+        fields = (
+            'id',
+            'url',
+            'created_at',
+            'updated_at',
+            'image',
+            'media_resource_categories_url',
+            'media_resources_url',
+            'name',
+            'profiles_url',
+            'quote')
         model = models.KMUser
 
 
@@ -38,28 +54,11 @@ class KMUserDetailSerializer(KMUserListSerializer):
 
     This serializer builds off of the ``KMUserListSerializer``.
     """
-    media_resource_categories_url = serializers.HyperlinkedIdentityField(
-        view_name='know-me:profile:media-resource-category-list')
-    media_resources_url = serializers.HyperlinkedIdentityField(
-        view_name='know-me:profile:media-resource-list')
+    permissions = DRYPermissionsField()
     profiles = ProfileListSerializer(many=True, read_only=True)
-    profiles_url = serializers.HyperlinkedIdentityField(
-        view_name='know-me:profile:profile-list')
 
-    class Meta:
-        extra_kwargs = EXTRA_FIELD_KWARGS
-        fields = (
-            'id',
-            'url',
-            'name',
-            'image',
-            'quote',
-            'media_resource_categories_url',
-            'media_resources_url',
-            'profiles_url',
-            'profiles',
-        )
-        model = models.KMUser
+    class Meta(KMUserListSerializer.Meta):
+        fields = KMUserListSerializer.Meta.fields + ('permissions', 'profiles')
 
 
 class KMUserAccessorSerializer(serializers.ModelSerializer):

--- a/km_api/know_me/tests/serializers/test_km_user_detail_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_detail_serializer.py
@@ -3,45 +3,39 @@ from know_me.profile.factories import ProfileFactory
 from know_me.profile.serializers import ProfileListSerializer
 
 
-def test_serialize(
-        api_rf,
-        image,
-        km_user_factory,
-        serializer_context):
+def test_serialize(api_rf, image, km_user_factory):
     """
     Test serializing a km_user.
     """
     km_user = km_user_factory(image=image)
+    api_rf.user = km_user.user
+    request = api_rf.get('/')
+
     ProfileFactory(km_user=km_user)
     ProfileFactory(km_user=km_user)
 
     serializer = serializers.KMUserDetailSerializer(
         km_user,
-        context=serializer_context)
+        context={'request': request})
+
+    list_serializer = serializers.KMUserListSerializer(
+        km_user,
+        context={'request': request})
     profile_serializer = ProfileListSerializer(
         km_user.profiles,
-        context=serializer_context,
+        context={'request': request},
         many=True)
 
-    request = serializer_context['request']
-
-    url = api_rf.get(km_user.get_absolute_url()).build_absolute_uri()
-    category_url = km_user.get_media_resource_category_list_url(request)
-    image_url = api_rf.get(km_user.image.url).build_absolute_uri()
-    media_resource_request = api_rf.get(km_user.get_media_resource_list_url())
-    profile_list_url = km_user.get_profile_list_url(request)
-
-    expected = {
-        'id': km_user.id,
-        'url': url,
-        'name': km_user.name,
-        'quote': km_user.quote,
-        'image': image_url,
-        'media_resource_categories_url': category_url,
-        'media_resources_url': media_resource_request.build_absolute_uri(),
-        'profiles_url': profile_list_url,
+    additional = {
+        'permissions': {
+            'read': km_user.has_object_read_permission(request),
+            'write': km_user.has_object_write_permission(request),
+        },
         'profiles': profile_serializer.data,
     }
+
+    expected = dict(list_serializer.data.items())
+    expected.update(additional)
 
     assert serializer.data == expected
 

--- a/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
@@ -25,27 +25,39 @@ def test_create(serializer_context, user_factory):
     assert km_user.user == user
 
 
-def test_serialize(
-        api_rf,
-        image,
-        km_user_factory,
-        serializer_context):
+def test_serialize(api_rf, image, km_user_factory, serialized_time):
     """
     Test serializing a km_user.
     """
     km_user = km_user_factory(image=image)
+    request = api_rf.get(km_user.get_absolute_url())
+
     serializer = serializers.KMUserListSerializer(
         km_user,
-        context=serializer_context)
+        context={'request': request})
 
     image_url = api_rf.get(km_user.image.url).build_absolute_uri()
-    url_request = api_rf.get(km_user.get_absolute_url())
+
+    categories_request = api_rf.get(
+        km_user.get_media_resource_category_list_url())
+    categories_url = categories_request.build_absolute_uri()
+
+    media_resources_request = api_rf.get(km_user.get_media_resource_list_url())
+    media_resources_url = media_resources_request.build_absolute_uri()
+
+    profiles_request = api_rf.get(km_user.get_profile_list_url())
+    profiles_url = profiles_request.build_absolute_uri()
 
     expected = {
         'id': km_user.id,
+        'url': request.build_absolute_uri(),
+        'created_at': serialized_time(km_user.created_at),
+        'updated_at': serialized_time(km_user.updated_at),
         'image': image_url,
-        'url': url_request.build_absolute_uri(),
+        'media_resource_categories_url': categories_url,
+        'media_resources_url': media_resources_url,
         'name': km_user.user.get_short_name(),
+        'profiles_url': profiles_url,
         'quote': km_user.quote,
     }
 


### PR DESCRIPTION
Closes #276 

### Proposed Changes

Rather than only returning the URLs for additional related resources in
the detail view for a Know Me user, we now return them from the user
list endpoint. This allows clients to obtain these URLs without making a
separate request for each user.