### PR TITLE
Fix documentation generation.

### DIFF
--- a/km_api/km_api/urls.py
+++ b/km_api/km_api/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),     # noqa
     url(r'^auth/', include('km_auth.urls', namespace='auth')),
-    url(r'^docs/', include_docs_urls(title='Know Me API')),
+    url(r'^docs/', include_docs_urls(public=False, title='Know Me API')),
     url(r'^know-me/', include('know_me.urls', namespace='know-me')),
 ]


### PR DESCRIPTION
Closes #285 

By adding 'public=False' when generating the docs, we can include a
request when instantiating our views which avoids problems when checking
attributes of the request.

<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->
