### PR TITLE
Fix missing endpoints in documentation.

### DIFF
--- a/km_api/km_api/urls.py
+++ b/km_api/km_api/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),     # noqa
     url(r'^auth/', include('km_auth.urls')),
-    url(r'^docs/', include_docs_urls(public=False, title='Know Me API')),
+    url(r'^docs/', include_docs_urls(title='Know Me API')),
     url(r'^know-me/', include('know_me.urls')),
 ]

--- a/km_api/know_me/journal/tests/views/test_entry_list_view.py
+++ b/km_api/know_me/journal/tests/views/test_entry_list_view.py
@@ -68,6 +68,19 @@ def test_get_serializer_class_get(api_rf):
     assert view.get_serializer_class() == expected
 
 
+def test_get_serializer_class_missing_request(api_rf):
+    """
+    When the documentation is generated, no request is provided to the
+    view. In this case we should return the list serializer.
+    """
+    view = views.EntryListView()
+    view.request = None
+
+    expected = serializers.EntryListSerializer
+
+    assert view.get_serializer_class() == expected
+
+
 def test_get_serializer_class_post(api_rf):
     """
     The view should use the entry detail serializer for a POST request.

--- a/km_api/know_me/journal/views.py
+++ b/km_api/know_me/journal/views.py
@@ -117,7 +117,7 @@ class EntryListView(generics.ListCreateAPIView):
             The entry detail serializer for a POST request and the list
             serializer for any other method.
         """
-        if self.request.method == 'POST':
+        if self.request and self.request.method == 'POST':
             return serializers.EntryDetailSerializer
 
         return serializers.EntryListSerializer


### PR DESCRIPTION
Fixes #285

Our previous fix for the documentation generation resulted in endpoints
being excluded from the docs. The new fix means that we will have to
check for 'request is None' in any view code that is used by the
generated docs.
