### PR TITLE
Split profile serializers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ v0.8.0
 
 Breaking Changes
   * :issue:`253`: Massive rewrite of profile features. This is a backwards incompatible change that modifies endpoints, the data returned from profile endpoints, and requires a complete database wipe.
+  * :issue:`258`: Require multiple calls to return full profile.
   * :issue:`267`: Refactor accessor permission fields. The permissions are now encompassed in a single ``is_admin`` field.
 
 Features

--- a/km_api/know_me/profile/tests/integration/test_profile_item_detail_view.py
+++ b/km_api/know_me/profile/tests/integration/test_profile_item_detail_view.py
@@ -39,7 +39,7 @@ def test_get_profile_item(api_client, api_rf, profile_item_factory):
 
     assert response.status_code == status.HTTP_200_OK
 
-    serializer = serializers.ProfileItemSerializer(
+    serializer = serializers.ProfileItemDetailSerializer(
         item,
         context={'request': request})
 

--- a/km_api/know_me/profile/tests/integration/test_profile_item_list_view.py
+++ b/km_api/know_me/profile/tests/integration/test_profile_item_list_view.py
@@ -27,7 +27,7 @@ def test_create_profile_item(api_client, api_rf, profile_topic_factory):
 
     assert response.status_code == status.HTTP_201_CREATED
 
-    serializer = serializers.ProfileItemSerializer(
+    serializer = serializers.ProfileItemDetailSerializer(
         topic.items.get(),
         context={'request': request})
 
@@ -59,7 +59,7 @@ def test_get_profile_item_list(
 
     assert response.status_code == status.HTTP_200_OK
 
-    serializer = serializers.ProfileItemSerializer(
+    serializer = serializers.ProfileItemListSerializer(
         topic.items.all(),
         context={'request': request},
         many=True)

--- a/km_api/know_me/profile/tests/integration/test_profile_topic_detail_view.py
+++ b/km_api/know_me/profile/tests/integration/test_profile_topic_detail_view.py
@@ -39,7 +39,7 @@ def test_get_profile_topic(api_client, api_rf, profile_topic_factory):
 
     assert response.status_code == status.HTTP_200_OK
 
-    serializer = serializers.ProfileTopicSerializer(
+    serializer = serializers.ProfileTopicListSerializer(
         topic,
         context={'request': request})
 

--- a/km_api/know_me/profile/tests/integration/test_profile_topic_list_view.py
+++ b/km_api/know_me/profile/tests/integration/test_profile_topic_list_view.py
@@ -6,37 +6,6 @@ from know_me.profile import serializers
 
 
 @pytest.mark.integration
-def test_create_profile_topic(
-        api_client,
-        api_rf,
-        profile_factory):
-    """
-    Sending a POST request to the view should create a new profile topic
-    for the specified profile.
-    """
-    profile = profile_factory()
-
-    api_client.force_authenticate(user=profile.km_user.user)
-    api_rf.user = profile.km_user.user
-
-    data = {
-        'name': 'Test Topic',
-    }
-
-    url = profile.get_topic_list_url()
-    request = api_rf.post(url, data)
-    response = api_client.post(url, data)
-
-    assert response.status_code == status.HTTP_201_CREATED
-
-    serializer = serializers.ProfileTopicSerializer(
-        profile.topics.get(),
-        context={'request': request})
-
-    assert response.data == serializer.data
-
-
-@pytest.mark.integration
 def test_get_profile_topics(
         api_client,
         api_rf,
@@ -60,9 +29,40 @@ def test_get_profile_topics(
 
     assert response.status_code == status.HTTP_200_OK
 
-    serializer = serializers.ProfileTopicSerializer(
+    serializer = serializers.ProfileTopicListSerializer(
         profile.topics.all(),
         context={'request': request},
         many=True)
+
+    assert response.data == serializer.data
+
+
+@pytest.mark.integration
+def test_post_profile_topic(
+        api_client,
+        api_rf,
+        profile_factory):
+    """
+    Sending a POST request to the view should create a new profile topic
+    for the specified profile.
+    """
+    profile = profile_factory()
+
+    api_client.force_authenticate(user=profile.km_user.user)
+    api_rf.user = profile.km_user.user
+
+    data = {
+        'name': 'Test Topic',
+    }
+
+    url = profile.get_topic_list_url()
+    request = api_rf.post(url, data)
+    response = api_client.post(url, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    serializer = serializers.ProfileTopicDetailSerializer(
+        profile.topics.get(),
+        context={'request': request})
 
     assert response.data == serializer.data

--- a/km_api/know_me/profile/tests/serializers/test_list_entry_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_list_entry_serializer.py
@@ -6,7 +6,6 @@ def test_serialize(api_rf, list_entry_factory, serialized_time):
     Test serializing a list entry.
     """
     entry = list_entry_factory()
-
     api_rf.user = entry.profile_item.topic.profile.km_user.user
     request = api_rf.get(entry.get_absolute_url())
 
@@ -16,6 +15,7 @@ def test_serialize(api_rf, list_entry_factory, serialized_time):
 
     expected = {
         'id': entry.id,
+        'url': request.build_absolute_uri(),
         'created_at': serialized_time(entry.created_at),
         'updated_at': serialized_time(entry.updated_at),
         'permissions': {

--- a/km_api/know_me/profile/tests/serializers/test_profile_detail_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_detail_serializer.py
@@ -16,16 +16,13 @@ def test_serialize_profile(api_rf, profile_factory, profile_topic_factory):
     list_serializer = serializers.ProfileListSerializer(
         profile,
         context={'request': request})
-    topic_serializer = serializers.ProfileTopicSerializer(
+    topic_serializer = serializers.ProfileTopicListSerializer(
         profile.topics,
         context={'request': request},
         many=True)
 
-    topics_url = api_rf.get(profile.get_topic_list_url()).build_absolute_uri()
-
     additional = {
         'topics': topic_serializer.data,
-        'topics_url': topics_url,
     }
 
     expected = dict(list_serializer.data.items())

--- a/km_api/know_me/profile/tests/serializers/test_profile_item_list_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_item_list_serializer.py
@@ -1,0 +1,37 @@
+from know_me.profile import serializers
+
+
+def test_serialize(api_rf, image, profile_item_factory, serialized_time):
+    """
+    Test serializing a profile item.
+    """
+    item = profile_item_factory(image=image)
+    api_rf.user = item.topic.profile.km_user.user
+    request = api_rf.get(item.get_absolute_url())
+
+    serializer = serializers.ProfileItemListSerializer(
+        item,
+        context={'request': request})
+
+    list_entries_request = api_rf.get(item.get_list_entries_url())
+    list_entries_url = list_entries_request.build_absolute_uri()
+
+    image_url = api_rf.get(item.image.url).build_absolute_uri()
+
+    expected = {
+        'id': item.id,
+        'url': request.build_absolute_uri(),
+        'created_at': serialized_time(item.created_at),
+        'updated_at': serialized_time(item.updated_at),
+        'description': item.description,
+        'image': image_url,
+        'list_entries_url': list_entries_url,
+        'name': item.name,
+        'permissions': {
+            'read': item.has_object_read_permission(request),
+            'write': item.has_object_write_permission(request),
+        },
+        'topic_id': item.topic.id,
+    }
+
+    assert serializer.data == expected

--- a/km_api/know_me/profile/tests/serializers/test_profile_list_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_list_serializer.py
@@ -14,6 +14,8 @@ def test_serialize_profile(api_rf, profile_factory, serialized_time):
         profile,
         context={'request': request})
 
+    topics_url = api_rf.get(profile.get_topic_list_url()).build_absolute_uri()
+
     expected = {
         'id': profile.id,
         'url': request.build_absolute_uri(),
@@ -24,6 +26,7 @@ def test_serialize_profile(api_rf, profile_factory, serialized_time):
             'read': profile.has_object_read_permission(request),
             'write': profile.has_object_write_permission(request),
         },
+        'topics_url': topics_url,
     }
 
     assert serializer.data == expected

--- a/km_api/know_me/profile/tests/serializers/test_profile_topic_detail_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_topic_detail_serializer.py
@@ -1,0 +1,48 @@
+from know_me.profile import serializers
+
+
+def test_serialize(api_rf, profile_item_factory, profile_topic_factory):
+    """
+    Test serializing a profile topic.
+    """
+    topic = profile_topic_factory()
+    api_rf.user = topic.profile.km_user.user
+    request = api_rf.get(topic.get_absolute_url())
+
+    profile_item_factory(topic=topic)
+    profile_item_factory(topic=topic)
+
+    serializer = serializers.ProfileTopicDetailSerializer(
+        topic,
+        context={'request': request})
+
+    item_serializer = serializers.ProfileItemListSerializer(
+        topic.items.all(),
+        context={'request': request},
+        many=True)
+    list_serializer = serializers.ProfileTopicListSerializer(
+        topic,
+        context={'request': request})
+
+    additional = {
+        'items': item_serializer.data,
+    }
+
+    expected = dict(list_serializer.data.items())
+    expected.update(additional)
+
+    assert serializer.data == expected
+
+
+def test_validate():
+    """
+    Test validating the attributes required to create a new profile
+    topic.
+    """
+    data = {
+        'is_detailed': True,
+        'name': 'Test Topic',
+    }
+    serializer = serializers.ProfileTopicDetailSerializer(data=data)
+
+    assert serializer.is_valid()

--- a/km_api/know_me/profile/tests/serializers/test_profile_topic_list_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_topic_list_serializer.py
@@ -10,9 +10,11 @@ def test_serialize(api_rf, profile_topic_factory, serialized_time):
     api_rf.user = topic.profile.km_user.user
     request = api_rf.get(topic.get_absolute_url())
 
-    serializer = serializers.ProfileTopicSerializer(
+    serializer = serializers.ProfileTopicListSerializer(
         topic,
         context={'request': request})
+
+    items_url = api_rf.get(topic.get_item_list_url()).build_absolute_uri()
 
     expected = {
         'id': topic.id,
@@ -20,6 +22,7 @@ def test_serialize(api_rf, profile_topic_factory, serialized_time):
         'created_at': serialized_time(topic.created_at),
         'updated_at': serialized_time(topic.updated_at),
         'is_detailed': topic.is_detailed,
+        'items_url': items_url,
         'name': topic.name,
         'permissions': {
             'read': topic.has_object_read_permission(request),
@@ -29,17 +32,3 @@ def test_serialize(api_rf, profile_topic_factory, serialized_time):
     }
 
     assert serializer.data == expected
-
-
-def test_validate():
-    """
-    Test validating the attributes required to create a new profile
-    topic.
-    """
-    data = {
-        'is_detailed': True,
-        'name': 'Test Topic',
-    }
-    serializer = serializers.ProfileTopicSerializer(data=data)
-
-    assert serializer.is_valid()

--- a/km_api/know_me/profile/tests/views/test_profile_item_detail_view.py
+++ b/km_api/know_me/profile/tests/views/test_profile_item_detail_view.py
@@ -33,6 +33,6 @@ def test_get_serializer_class():
     Test the serializer class the view uses.
     """
     view = views.ProfileItemDetailView()
-    expected = serializers.ProfileItemSerializer
+    expected = serializers.ProfileItemDetailSerializer
 
     assert view.get_serializer_class() == expected

--- a/km_api/know_me/profile/tests/views/test_profile_item_list_view.py
+++ b/km_api/know_me/profile/tests/views/test_profile_item_list_view.py
@@ -32,12 +32,39 @@ def test_get_queryset(profile_item_factory, profile_topic_factory):
     assert list(view.get_queryset()) == list(topic.items.all())
 
 
-def test_get_serializer_class():
+def test_get_serializer_class_get(api_rf):
     """
-    Test the serializer class used by the view.
+    The view should use the list serializer for a GET request.
     """
     view = views.ProfileItemListView()
-    expected = serializers.ProfileItemSerializer
+    view.request = api_rf.get('/')
+
+    expected = serializers.ProfileItemListSerializer
+
+    assert view.get_serializer_class() == expected
+
+
+def test_get_serializer_class_missing_request():
+    """
+    The view should use the detail serializer if the request is
+    ``None``.
+    """
+    view = views.ProfileItemListView()
+    view.request = None
+
+    expected = serializers.ProfileItemDetailSerializer
+
+    assert view.get_serializer_class() == expected
+
+
+def test_get_serializer_class_post(api_rf):
+    """
+    The view should use the detail serializer for POST requests.
+    """
+    view = views.ProfileItemListView()
+    view.request = api_rf.post('/')
+
+    expected = serializers.ProfileItemDetailSerializer
 
     assert view.get_serializer_class() == expected
 

--- a/km_api/know_me/profile/tests/views/test_profile_topic_detail_view.py
+++ b/km_api/know_me/profile/tests/views/test_profile_topic_detail_view.py
@@ -33,6 +33,6 @@ def test_get_serializer_class():
     Test the serializer class the view uses.
     """
     view = views.ProfileTopicDetailView()
-    expected = serializers.ProfileTopicSerializer
+    expected = serializers.ProfileTopicListSerializer
 
     assert view.get_serializer_class() == expected

--- a/km_api/know_me/profile/tests/views/test_profile_topic_list_view.py
+++ b/km_api/know_me/profile/tests/views/test_profile_topic_list_view.py
@@ -32,12 +32,39 @@ def test_get_queryset(profile_factory, profile_topic_factory):
     assert list(view.get_queryset()) == list(profile.topics.all())
 
 
-def test_get_serializer_class():
+def test_get_serializer_class_get(api_rf):
     """
-    Test the serializer class used by the view.
+    The view should use the list serializer for a GET request.
     """
     view = views.ProfileTopicListView()
-    expected = serializers.ProfileTopicSerializer
+    view.request = api_rf.get('/')
+
+    expected = serializers.ProfileTopicListSerializer
+
+    assert view.get_serializer_class() == expected
+
+
+def test_get_serializer_class_missing_request():
+    """
+    If the view's request instance is ``None``, the detail serializer
+    should be used.
+    """
+    view = views.ProfileTopicListView()
+    view.request = None
+
+    expected = serializers.ProfileTopicDetailSerializer
+
+    assert view.get_serializer_class() == expected
+
+
+def test_get_serializer_class_post(api_rf):
+    """
+    The view should use the detail serializer for a POST request.
+    """
+    view = views.ProfileTopicListView()
+    view.request = api_rf.post('/')
+
+    expected = serializers.ProfileTopicDetailSerializer
 
     assert view.get_serializer_class() == expected
 

--- a/km_api/know_me/profile/views.py
+++ b/km_api/know_me/profile/views.py
@@ -258,7 +258,7 @@ class ProfileItemDetailView(generics.RetrieveUpdateDestroyAPIView):
     """
     permission_classes = (DRYPermissions,)
     queryset = models.ProfileItem.objects.all()
-    serializer_class = serializers.ProfileItemSerializer
+    serializer_class = serializers.ProfileItemDetailSerializer
 
 
 class ProfileItemListView(generics.ListCreateAPIView):
@@ -273,7 +273,7 @@ class ProfileItemListView(generics.ListCreateAPIView):
         DRYPermissions,
         permissions.HasProfileItemListPermissions,
     )
-    serializer_class = serializers.ProfileItemSerializer
+    serializer_class = serializers.ProfileItemDetailSerializer
 
     def get_queryset(self):
         """
@@ -289,6 +289,20 @@ class ProfileItemListView(generics.ListCreateAPIView):
             ID is given in the URL.
         """
         return models.ProfileItem.objects.filter(topic=self.kwargs.get('pk'))
+
+    def get_serializer_class(self):
+        """
+        Get the appropriate serializer class for the current request.
+
+        Returns:
+            The profile item detail serializer if the request is missing
+            or it is a POST request. The profile item list serializer is
+            used otherwise.
+        """
+        if self.request is None or self.request.method == 'POST':
+            return serializers.ProfileItemDetailSerializer
+
+        return serializers.ProfileItemListSerializer
 
     def get_serializer_context(self):
         """
@@ -341,7 +355,7 @@ class ProfileTopicDetailView(generics.RetrieveUpdateDestroyAPIView):
     """
     permission_classes = (DRYPermissions,)
     queryset = models.ProfileTopic.objects.all()
-    serializer_class = serializers.ProfileTopicSerializer
+    serializer_class = serializers.ProfileTopicListSerializer
 
 
 class ProfileTopicListView(generics.ListCreateAPIView):
@@ -356,7 +370,6 @@ class ProfileTopicListView(generics.ListCreateAPIView):
         DRYPermissions,
         permissions.HasProfileTopicListPermissions,
     )
-    serializer_class = serializers.ProfileTopicSerializer
 
     def get_queryset(self):
         """
@@ -373,6 +386,19 @@ class ProfileTopicListView(generics.ListCreateAPIView):
         """
         return models.ProfileTopic.objects.filter(
             profile__pk=self.kwargs.get('pk'))
+
+    def get_serializer_class(self):
+        """
+        Get the correct serializer class for the given request.
+
+        Returns:
+            The profile topic detail serializer if there is no request
+            or it is a POST request and the list serializer otherwise.
+        """
+        if self.request is None or self.request.method == 'POST':
+            return serializers.ProfileTopicDetailSerializer
+
+        return serializers.ProfileTopicListSerializer
 
     def perform_create(self, serializer):
         """


### PR DESCRIPTION
Closes #258

The serializers responsible for returning different parts of a profile
have been split into list and detail variants. The detail variants
include the same information as the list serializers with the next level
of the profile hierarchy included. For example, the profile topic detail
serializer includes the topic's items.

This change was made to avoid potential future performance issues
resulting from returning an entire profile in one call.
