### PR TITLE
Add missing fields to entry serializer

### DIFF
--- a/km_api/know_me/journal/serializers.py
+++ b/km_api/know_me/journal/serializers.py
@@ -31,6 +31,9 @@ class EntryListSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for a list of journal entries.
     """
+    comment_count = serializers.IntegerField(
+        read_only=True,
+        source='comments.count')
     comments_url = serializers.HyperlinkedIdentityField(
         view_name='know-me:journal:entry-comment-list')
     url = serializers.HyperlinkedIdentityField(
@@ -42,8 +45,11 @@ class EntryListSerializer(serializers.HyperlinkedModelSerializer):
             'url',
             'created_at',
             'updated_at',
+            'attachment',
+            'comment_count',
             'comments_url',
-            'km_user_id')
+            'km_user_id',
+            'text')
         model = models.Entry
 
 
@@ -55,7 +61,4 @@ class EntryDetailSerializer(EntryListSerializer):
     permissions = DRYPermissionsField()
 
     class Meta(EntryListSerializer.Meta):
-        fields = EntryListSerializer.Meta.fields + (
-            'comments',
-            'permissions',
-            'text')
+        fields = EntryListSerializer.Meta.fields + ('comments', 'permissions')

--- a/km_api/know_me/journal/tests/serializers/test_entry_detail_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_entry_detail_serializer.py
@@ -29,7 +29,6 @@ def test_serialize(api_rf, entry_comment_factory, entry_factory):
             'read': entry.has_object_read_permission(request),
             'write': entry.has_object_write_permission(request),
         },
-        'text': entry.text,
     }
 
     expected = dict(list_serializer.data.items())

--- a/km_api/know_me/journal/tests/serializers/test_entry_list_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_entry_list_serializer.py
@@ -1,26 +1,38 @@
 from know_me.journal import serializers
 
 
-def test_serialize(api_rf, entry_factory, serialized_time):
+def test_serialize(
+        api_rf,
+        entry_comment_factory,
+        entry_factory,
+        image,
+        serialized_time):
     """
     Test serializing a journal entry.
     """
-    entry = entry_factory()
+    entry = entry_factory(attachment=image)
     request = api_rf.get(entry.get_absolute_url())
+
+    entry_comment_factory(entry=entry)
+    entry_comment_factory(entry=entry)
 
     serializer = serializers.EntryListSerializer(
         entry,
         context={'request': request})
 
     comments_url = api_rf.get(entry.get_comments_url()).build_absolute_uri()
+    attachment_url = api_rf.get(entry.attachment.url).build_absolute_uri()
 
     expected = {
         'id': entry.id,
         'url': request.build_absolute_uri(),
         'created_at': serialized_time(entry.created_at),
         'updated_at': serialized_time(entry.updated_at),
+        'attachment': attachment_url,
+        'comment_count': entry.comments.count(),
         'comments_url': comments_url,
         'km_user_id': entry.km_user.id,
+        'text': entry.text,
     }
 
     assert serializer.data == expected

--- a/km_api/know_me/journal/tests/views/test_entry_list_view.py
+++ b/km_api/know_me/journal/tests/views/test_entry_list_view.py
@@ -155,12 +155,12 @@ def test_get_serializer_class_get(api_rf):
 def test_get_serializer_class_missing_request(api_rf):
     """
     When the documentation is generated, no request is provided to the
-    view. In this case we should return the list serializer.
+    view. In this case we should return the detail serializer.
     """
     view = views.EntryListView()
     view.request = None
 
-    expected = serializers.EntryListSerializer
+    expected = serializers.EntryDetailSerializer
 
     assert view.get_serializer_class() == expected
 

--- a/km_api/know_me/journal/views.py
+++ b/km_api/know_me/journal/views.py
@@ -147,7 +147,7 @@ class EntryListView(generics.ListCreateAPIView):
             The entry detail serializer for a POST request and the list
             serializer for any other method.
         """
-        if self.request and self.request.method == 'POST':
+        if self.request is None or self.request.method == 'POST':
             return serializers.EntryDetailSerializer
 
         return serializers.EntryListSerializer


### PR DESCRIPTION
Fixes #291 
Closes #293 

The entry list serializer now returns the entry's text, a link to its attachment, and the number of comments it has.