### PR TITLE
Fix issue with creating mailchimp user.

### DIFF
--- a/km_api/mailing_list/mailchimp_utils.py
+++ b/km_api/mailing_list/mailchimp_utils.py
@@ -7,8 +7,6 @@ from django.conf import settings
 
 import mailchimp3
 
-from requests.exceptions import HTTPError
-
 from rest_email_auth.models import EmailAddress
 
 from mailing_list import models
@@ -107,7 +105,7 @@ def _member_create(list_id, user):
             data=data,
             list_id=list_id)
         logger.info('Subscribed %s to mailing list', user.primary_email.email)
-    except HTTPError:
+    except mailchimp3.mailchimpclient.MailChimpError:
         # When updating a user's info we don't want to set them to
         # subscribed
         del data['status']
@@ -156,7 +154,7 @@ def _member_update(list_id, user, mailchimp_user):
         logger.info(
             'Updated mailing list info for %s.',
             user.primary_email.email)
-    except HTTPError:
+    except mailchimp3.mailchimpclient.MailChimpError:
         data.update({'status': 'subscribed'})
 
         response = client.lists.members.create(

--- a/km_api/mailing_list/tests/mailchimp_utils/test_member_create.py
+++ b/km_api/mailing_list/tests/mailchimp_utils/test_member_create.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from requests.exceptions import HTTPError
+from mailchimp3.mailchimpclient import MailChimpError
 
 from mailing_list import mailchimp_utils, models
 
@@ -49,10 +49,7 @@ def test_create_member_exists(mock_mc_client, user_factory):
     user = user_factory()
 
     def mock_create(*args, **kwargs):
-        """
-        Raise a ``HttpError`` exception.
-        """
-        raise HTTPError()
+        raise MailChimpError()
 
     mock_mc_client.lists.members.create.side_effect = mock_create
     mock_mc_client.lists.members.update.return_value = {

--- a/km_api/mailing_list/tests/mailchimp_utils/test_member_update.py
+++ b/km_api/mailing_list/tests/mailchimp_utils/test_member_update.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from requests.exceptions import HTTPError
+from mailchimp3.mailchimpclient import MailChimpError
 
 from mailing_list import mailchimp_utils, models
 
@@ -45,7 +45,7 @@ def test_update_user_nonexistent(mailchimp_user_factory, mock_mc_client):
     mailchimp_user = mailchimp_user_factory()
     user = mailchimp_user.user
 
-    mock_mc_client.lists.members.update.side_effect = HTTPError
+    mock_mc_client.lists.members.update.side_effect = MailChimpError
     mock_mc_client.lists.members.create.return_value = {
         'id': 'hash',
     }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,5 +14,4 @@ djangorestframework == 3.7.7
 dry-rest-permissions == 0.1.10
 mailchimp3 == 3.0.1
 raven == 6.6.0
-requests == 2.18.4
 watchtower == 0.5.2


### PR DESCRIPTION
Fixes #307

It appears the exception raised when trying to create a user who exists
has changed, so we now catch the correct exception.
