### PR TITLE
Allow profile item media resource detachment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ km_api/static/
 tfplan
 *.retry
 VAULT_PASSWORD_FILE
+
+# Pycharm Files
+.idea/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Features
   * :issue:`263,277`: Automatically create a Know Me user for each user. The Know Me user's image defaults to the user's profile image.
   * :issue:`278`: Include information about the user granted access through an accessor.
   * :issue:`299`: Add additional information to media resources. The resources can have a link instead of a file, and they have an integer to hint how they should be styled.
+  * :issue:`321`: Allow media resources to be detached from profile items.
 
 
 ******

--- a/km_api/know_me/profile/serializers.py
+++ b/km_api/know_me/profile/serializers.py
@@ -147,6 +147,7 @@ class ProfileItemDetailSerializer(ProfileItemListSerializer):
     list_entries = ListEntrySerializer(many=True, read_only=True)
     media_resource = MediaResourceSerializer(read_only=True)
     media_resource_id = serializers.PrimaryKeyRelatedField(
+        allow_null=True,
         help_text=_('The ID of the media resource to attach to the item.'),
         queryset=models.MediaResource.objects.all(),
         required=False,
@@ -182,6 +183,9 @@ class ProfileItemDetailSerializer(ProfileItemListSerializer):
                 If there is no media resource with the provided ID owned
                 by the relevant Know Me user.
         """
+        if resource is None:
+            return resource
+
         if self.instance is not None:
             km_user = self.instance.topic.profile.km_user
         else:

--- a/km_api/know_me/profile/tests/integration/test_profile_item_detail_view.py
+++ b/km_api/know_me/profile/tests/integration/test_profile_item_detail_view.py
@@ -51,6 +51,38 @@ def test_delete_profile_item(api_client, profile_item_factory):
 
 
 @pytest.mark.integration
+def test_detach_media_resource(
+        api_client,
+        media_resource_factory,
+        profile_item_factory):
+    """
+    Sending a null value for the media resource attached to a profile
+    item should detach any media resource from the specified profile
+    item.
+
+    Regression test for #321
+    """
+    resource = media_resource_factory()
+    item = profile_item_factory(
+        media_resource=resource,
+        topic__profile__km_user=resource.km_user)
+
+    api_client.force_authenticate(user=resource.km_user.user)
+
+    data = {
+        'media_resource_id': '',
+    }
+
+    url = item.get_absolute_url()
+    response = api_client.patch(url, data)
+
+    item.refresh_from_db()
+
+    assert response.status_code == status.HTTP_200_OK, response.data
+    assert item.media_resource is None
+
+
+@pytest.mark.integration
 def test_get_profile_item(api_client, api_rf, profile_item_factory):
     """
     Sending a GET request to the view should return the information of

--- a/km_api/know_me/profile/tests/serializers/test_profile_item_detail_serializer.py
+++ b/km_api/know_me/profile/tests/serializers/test_profile_item_detail_serializer.py
@@ -105,15 +105,43 @@ def test_validate_media_resource_id_by_item(
     assert result == media_resource
 
 
-def test_validate_media_resource_id_missing_context():
+def test_validate_media_resource_id_missing_context(media_resource_factory):
     """
     If the serializer is not bound and a Know Me user isn't provided as
     context, an AssertionError should be raised.
     """
+    resource = media_resource_factory()
     serializer = serializers.ProfileItemDetailSerializer()
 
     with pytest.raises(AssertionError):
-        serializer.validate_media_resource_id(None)
+        serializer.validate_media_resource_id(resource)
+
+
+def test_validate_media_resource_id_null(
+        km_user_factory,
+        media_resource_factory,
+        profile_item_factory):
+    """
+    Setting ``media_resource_id`` to ``None`` should detach the media resource
+    from the profile item.
+
+    Regression test for #321
+    """
+    km_user = km_user_factory()
+    resource = media_resource_factory(km_user=km_user)
+    item = profile_item_factory(
+        media_resource=resource,
+        topic__profile__km_user=km_user)
+
+    data = {
+        'media_resource_id': None,
+    }
+    serializer = serializers.ProfileItemDetailSerializer(
+        item,
+        data=data,
+        partial=True)
+
+    assert serializer.is_valid()
 
 
 def test_validate_media_resource_id_other_user(


### PR DESCRIPTION
Closes #321

By passing in an empty string (or null value), a profile item can now be set to have no attached media resource.