### PR TITLE
Add separate endpoint to accept accessor.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 **************
 
 Breaking Changes
+  * :issue:`296`: Add separate endpoint to accept an accessor.
   * :issue:`316`: Paginate journal entries. The entries are now nested under the ``results`` key, and there is additional information returned such as the total number of entries and the URLs for the next and previous pages. Entries are listed in reverse chronological order.
 
 Features

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -351,6 +351,13 @@ class KMUserAccessor(mixins.IsAuthenticatedMixin, models.Model):
         """
         return 'Accessor for {user}'.format(user=self.km_user.name)
 
+    @property
+    def accept_url(self):
+        """
+        The absolute URL of the accessor's accept view.
+        """
+        return reverse('know-me:accessor-accept', kwargs={'pk': self.pk})
+
     def get_absolute_url(self, request=None):
         """
         Get the URL of the instance's detail view.
@@ -370,3 +377,50 @@ class KMUserAccessor(mixins.IsAuthenticatedMixin, models.Model):
             'know-me:accessor-detail',
             kwargs={'pk': self.pk},
             request=request)
+
+    def has_object_accept_permission(self, request):
+        """
+        Check if the requesting user can accept the accessor.
+
+        Only the user granted access through the accessor can accept it.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            A boolean indicating if the request user has permission to
+            accept the accessor.
+        """
+        return request.user == self.user_with_access
+
+    def has_object_read_permission(self, request):
+        """
+        Check read permissions on the instance for a request.
+
+        Users have read access if they are the owner of the Know Me user
+        or have been granted access through an accessor.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            A boolean indicating if the requesting user has read access
+            to the instance.
+        """
+        return request.user in [self.km_user.user, self.user_with_access]
+
+    def has_object_write_permission(self, request):
+        """
+        Check write permissions on the instance for a request.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            A boolean indicating if the requesting user has write access
+            to the instance.
+        """
+        return request.user == self.km_user.user

--- a/km_api/know_me/tests/models/test_km_user_accessor_model.py
+++ b/km_api/know_me/tests/models/test_km_user_accessor_model.py
@@ -3,6 +3,17 @@ from rest_framework.reverse import reverse
 from know_me import models
 
 
+def test_accept_url(km_user_accessor_factory):
+    """
+    This property should contain the absolute URL of the accessor's
+    accept view.
+    """
+    accessor = km_user_accessor_factory()
+    expected = reverse('know-me:accessor-accept', kwargs={'pk': accessor.pk})
+
+    assert accessor.accept_url == expected
+
+
 def test_create(km_user_factory, user_factory):
     """
     Test creating a KMUserAccessor.
@@ -37,6 +48,125 @@ def test_get_absolute_url_with_request(api_rf, km_user_accessor_factory):
     expected = request.build_absolute_uri()
 
     assert accessor.get_absolute_url(request) == expected
+
+
+def test_has_object_accept_permission_accessee(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    The user granted access through the accessor should have permission
+    to accept the accessor.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory(user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert accessor.has_object_accept_permission(request)
+
+
+def test_has_object_accept_permission_owner(api_rf, km_user_accessor_factory):
+    """
+    The user who created the accessor should not be able to mark the
+    accessor as accepted.
+    """
+    accessor = km_user_accessor_factory()
+    api_rf.user = accessor.km_user.user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert not accessor.has_object_accept_permission(request)
+
+
+def test_has_object_read_permission_accessee(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    The user granted access through the accessor should have read
+    permissions on the accessor.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory(user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert accessor.has_object_read_permission(request)
+
+
+def test_has_object_read_permission_other(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    Other users should not have read access to accessors.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory()
+
+    api_rf.user = user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert not accessor.has_object_read_permission(request)
+
+
+def test_has_object_read_permission_owner(api_rf, km_user_accessor_factory):
+    """
+    The user who created the accessor should have read permissions on
+    it.
+    """
+    accessor = km_user_accessor_factory()
+    api_rf.user = accessor.km_user.user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert accessor.has_object_read_permission(request)
+
+
+def test_has_object_write_permission_accessee(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    The user granted access through the accessor should not have write
+    permissions on the accessor.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory(user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert not accessor.has_object_write_permission(request)
+
+
+def test_has_object_write_permission_other(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    Other users should not have write access to accessors.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory()
+
+    api_rf.user = user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert not accessor.has_object_write_permission(request)
+
+
+def test_has_object_write_permission_owner(api_rf, km_user_accessor_factory):
+    """
+    The user who created the accessor should have write permissions on
+    it.
+    """
+    accessor = km_user_accessor_factory()
+    api_rf.user = accessor.km_user.user
+    request = api_rf.get(accessor.get_absolute_url())
+
+    assert accessor.has_object_write_permission(request)
 
 
 def test_string_conversion(km_user_accessor_factory):

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -4,71 +4,6 @@ from account.serializers import UserInfoSerializer
 from know_me import serializers
 
 
-def test_accept(
-        api_rf,
-        km_user_accessor_factory,
-        user_factory):
-    """
-    The user who is invited through the accessor should be able to mark
-    the accessor as accepted.
-    """
-    user = user_factory()
-    accessor = km_user_accessor_factory(user_with_access=user)
-
-    api_rf.user = user
-    request = api_rf.get('/')
-
-    data = {'is_accepted': True}
-
-    serializer = serializers.KMUserAccessorSerializer(
-        accessor,
-        context={'request': request},
-        data=data,
-        partial=True)
-    assert serializer.is_valid()
-
-    serializer.save()
-    accessor.refresh_from_db()
-
-    assert accessor.is_accepted
-
-
-def test_accept_by_unauthorized_user(api_rf, km_user_accessor_factory):
-    """
-    Any user other than the user granted access by the accessor should
-    not be able to accept the accessor.
-    """
-    accessor = km_user_accessor_factory()
-
-    api_rf.user = accessor.km_user.user
-    request = api_rf.get('/')
-
-    data = {'is_accepted': True}
-
-    serializer = serializers.KMUserAccessorSerializer(
-        accessor,
-        context={'request': request},
-        data=data,
-        partial=True)
-
-    assert not serializer.is_valid()
-    assert set(serializer.errors.keys()) == {'is_accepted'}
-
-
-def test_accept_on_create(db):
-    """
-    Attempt to create an accessor with ``is_accepted == True`` should
-    fail.
-    """
-    data = {
-        'email': 'test@example.com',
-        'is_accepted': True,
-    }
-
-    serializer = serializers.KMUserAccessorSerializer(data=data)
-    assert not serializer.is_valid()
-
-
 def test_create(km_user_factory):
     """
     Saving the serializer should use the Know Me user's ``share`` method
@@ -120,15 +55,24 @@ def test_serialize(
 
     url = request.build_absolute_uri()
 
+    accept_request = api_rf.get(accessor.accept_url)
+    accept_url = accept_request.build_absolute_uri()
+
     expected = {
         'id': accessor.id,
         'url': url,
         'created_at': serialized_time(accessor.created_at),
         'updated_at': serialized_time(accessor.updated_at),
+        'accept_url': accept_url,
         'email': accessor.email,
         'is_accepted': accessor.is_accepted,
         'is_admin': accessor.is_admin,
         'km_user_id': accessor.km_user.id,
+        'permissions': {
+            'accept': accessor.has_object_accept_permission(request),
+            'read': accessor.has_object_read_permission(request),
+            'write': accessor.has_object_write_permission(request),
+        },
         'user_with_access': user_serializer.data,
     }
 

--- a/km_api/know_me/tests/views/test_accessor_accept_view.py
+++ b/km_api/know_me/tests/views/test_accessor_accept_view.py
@@ -1,0 +1,60 @@
+from unittest import mock
+
+from rest_framework import status
+
+from know_me import models, views
+
+
+@mock.patch(
+    'know_me.views.DRYPermissions.has_object_permission',
+    autospec=True)
+def test_check_object_permissions(mock_dry_permissions, api_rf):
+    """
+    The view should check the permissions on the model.
+    """
+    view = views.AccessorAcceptView()
+
+    view.check_object_permissions(None, None)
+
+    assert mock_dry_permissions.call_count == 1
+
+
+def test_get_queryset(km_user_accessor_factory):
+    """
+    The view should operate on all accessors.
+    """
+    km_user_accessor_factory()
+    km_user_accessor_factory()
+    km_user_accessor_factory()
+
+    view = views.AccessorAcceptView()
+    expected = models.KMUserAccessor.objects.all()
+
+    assert list(view.get_queryset()) == list(expected)
+
+
+def test_post(api_rf, km_user_accessor_factory, user_factory):
+    """
+    Sending a POST request to the view should mark the accessor as
+    accepted.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory(
+        is_accepted=False,
+        user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.post('/', {})
+
+    view = views.AccessorAcceptView()
+    view.kwargs = {
+        'pk': accessor.pk,
+    }
+    view.request = request
+
+    response = view.post(request)
+
+    accessor.refresh_from_db()
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert accessor.is_accepted

--- a/km_api/know_me/tests/views/test_pending_accessor_list_view.py
+++ b/km_api/know_me/tests/views/test_pending_accessor_list_view.py
@@ -18,17 +18,19 @@ def test_get_pending_accessors(
     """
     user = user_factory()
     api_client.force_authenticate(user=user)
+    api_rf.user = user
 
     km_user_accessor_factory(is_accepted=False, user_with_access=user)
     km_user_accessor_factory(is_accepted=True, user_with_access=user)
 
+    request = api_rf.get(url)
     response = api_client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
 
     serializer = serializers.KMUserAccessorSerializer(
         user.km_user_accessors.filter(is_accepted=False),
-        context={'request': api_rf.get(url)},
+        context={'request': request},
         many=True)
 
     assert response.data == serializer.data

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name='accessor-detail'),
 
     url(
+        r'^accessors/(?P<pk>[0-9]+)/accept/$',
+        views.AccessorAcceptView.as_view(),
+        name='accessor-accept'),
+
+    url(
         r'^config/$',
         views.ConfigDetailView.as_view(),
         name='config-detail'),


### PR DESCRIPTION
Closes #296

Instead of modifying the accessor from its detail page to accept it, the
user granted access must send a request to the accessor's 'accept'
endpoint. This is simpler to both implement and understand.
