### PR TITLE
Remove endpoint for creating Know Me users.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 Breaking Changes
   * :issue:`296`: Add separate endpoint to accept an accessor.
   * :issue:`316`: Paginate journal entries. The entries are now nested under the ``results`` key, and there is additional information returned such as the total number of entries and the URLs for the next and previous pages. Entries are listed in reverse chronological order.
+  * :issue:`332`: Remove ability to manually create a Know Me user. As per :issue:`263`, a Know Me user is automatically created for each registered user.
 
 Features
   * :issue:`233`: Add config endpoint for Know Me app. It contains information such as the lowest useable iOS app version.

--- a/km_api/know_me/tests/views/test_km_user_list_view.py
+++ b/km_api/know_me/tests/views/test_km_user_list_view.py
@@ -8,52 +8,6 @@ km_user_list_view = views.KMUserListView.as_view()
 url = reverse('know-me:km-user-list')
 
 
-def test_create(api_rf, user_factory):
-    """
-    Sending a POST request with valid data to the view should create a
-    new km_user for the user making the request.
-    """
-    user = user_factory()
-    api_rf.user = user
-
-    data = {
-        'name': user.get_short_name(),
-        'quote': "Hi, I'm {name}".format(name=user.get_short_name()),
-    }
-
-    request = api_rf.post(url, data)
-    response = km_user_list_view(request)
-
-    assert response.status_code == status.HTTP_201_CREATED
-
-    serializer = serializers.KMUserListSerializer(
-        user.km_user,
-        context={'request': request})
-
-    assert response.data == serializer.data
-
-
-def test_create_second_km_user(api_rf, km_user_factory, user_factory):
-    """
-    A user who already has an associated ``KMUser`` instance should not
-    be able to create a second one.
-    """
-    user = user_factory()
-    api_rf.user = user
-
-    km_user_factory(user=user)
-
-    data = {
-        'name': user.get_short_name(),
-        'quote': "Hi, I'm {name}".format(name=user.get_short_name()),
-    }
-
-    request = api_rf.post(url, data)
-    response = km_user_list_view(request)
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-
 def test_get_own_km_user(api_rf, km_user_factory, user_factory):
     """
     If the requesting user has a km_user, then a GET request to this

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -3,12 +3,10 @@
 
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
 
 from dry_rest_permissions.generics import DRYGlobalPermissions, DRYPermissions
 
 from rest_framework import generics, pagination, status
-from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from know_me import models, serializers
@@ -156,16 +154,11 @@ class KMUserDetailView(generics.RetrieveUpdateAPIView):
     serializer_class = serializers.KMUserDetailSerializer
 
 
-class KMUserListView(generics.ListCreateAPIView):
+class KMUserListView(generics.ListAPIView):
     """
     get:
     Endpoint for listing the Know Me users that the current user has
     access to.
-
-    post:
-    Endpoint for creating a new Know Me user for the current user.
-
-    *__Note__: Users may only create one Know Me app account.*
     """
     permission_classes = (DRYPermissions,)
     serializer_class = serializers.KMUserListSerializer
@@ -186,24 +179,6 @@ class KMUserListView(generics.ListCreateAPIView):
         query |= Q(user=self.request.user)
 
         return models.KMUser.objects.filter(query)
-
-    def perform_create(self, serializer):
-        """
-        Create a new Know Me specific user for the requesting user.
-
-        Returns:
-            A new Know Me user.
-
-        Raises:
-            ValidationError:
-                If the user making the request already has a Know Me
-                specific account.
-        """
-        if hasattr(self.request.user, 'km_user'):
-            raise ValidationError(
-                _('Users may not have more than one Know Me account.'))
-
-        return serializer.save(user=self.request.user)
 
 
 class LegacyUserDetailView(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
Closes #332 

Know Me users are automatically created for each registered user, so we
don't need an endpoint to manually create them.
