### PR TITLE
Return the requesting user's KM user first.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Features
   * :issue:`299`: Add additional information to media resources. The resources can have a link instead of a file, and they have an integer to hint how they should be styled.
   * :issue:`306`: Add tracking of legacy users. The list of legacy users can be viewed/updated by staff.
   * :issue:`321`: Allow media resources to be detached from profile items.
+  * :issue:`326`: The Know Me user owned by the requesting user is guaranteed to be the first element in the list returned from ``/know-me/users/``. Each user in the list also has a new ``is_owned_by_current_user`` boolean attribute.
   * :issue:`328`: Increase maximum upload size to 100MB.
 
 

--- a/km_api/know_me/serializers.py
+++ b/km_api/know_me/serializers.py
@@ -27,6 +27,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for multiple ``KMUser`` instances.
     """
+    is_owned_by_current_user = serializers.SerializerMethodField()
     journal_entries_url = serializers.HyperlinkedIdentityField(
         view_name='know-me:journal:entry-list')
     media_resource_categories_url = serializers.HyperlinkedIdentityField(
@@ -54,6 +55,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             'url',
             'created_at',
             'updated_at',
+            'is_owned_by_current_user',
             'image',
             'journal_entries_url',
             'media_resource_categories_url',
@@ -61,8 +63,24 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             'name',
             'permissions',
             'profiles_url',
-            'quote')
+            'quote',
+        )
         model = models.KMUser
+
+    def get_is_owned_by_current_user(self, km_user):
+        """
+        Determine if the instance bound to the serializer is owned by
+        the requesting user.
+
+        Args:
+            km_user:
+                The Know Me user bound to the serializer.
+
+        Returns:
+            A boolean indicating if the requesting user owns the Know Me
+            user bound to the serializer.
+        """
+        return self.context['request'].user == km_user.user
 
 
 class KMUserDetailSerializer(KMUserListSerializer):

--- a/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
@@ -27,6 +27,26 @@ def test_create(serializer_context, user_factory):
     assert km_user.user == user
 
 
+def test_get_is_owned_by_current_user_not_owner(
+        api_rf,
+        km_user_factory,
+        user_factory):
+    """
+    If the requesting user is not the owner of the instance bound to the
+    serializer, this method should return ``False``.
+    """
+    user = user_factory()
+    api_rf.user = user
+    request = api_rf.get('/')
+
+    km_user = km_user_factory()
+    serializer = serializers.KMUserListSerializer(
+        km_user,
+        context={'request': request})
+
+    assert not serializer.get_is_owned_by_current_user(km_user)
+
+
 def test_serialize(api_rf, image, km_user_factory, serialized_time):
     """
     Test serializing a km_user.
@@ -63,6 +83,7 @@ def test_serialize(api_rf, image, km_user_factory, serialized_time):
         'created_at': serialized_time(km_user.created_at),
         'updated_at': serialized_time(km_user.updated_at),
         'image': image_url,
+        'is_owned_by_current_user': km_user.user == request.user,
         'journal_entries_url': entries_url,
         'media_resource_categories_url': categories_url,
         'media_resources_url': media_resources_url,

--- a/km_api/know_me/tests/views/test_km_user_list_view.py
+++ b/km_api/know_me/tests/views/test_km_user_list_view.py
@@ -30,6 +30,40 @@ def test_get_own_km_user(api_rf, km_user_factory, user_factory):
     assert response.data == serializer.data
 
 
+def test_get_queryset_order(
+        api_rf,
+        km_user_accessor_factory,
+        km_user_factory,
+        user_factory):
+    """
+    The list of Know Me users should have the requesting user's Know Me
+    user listed first, followed by any shared users.
+    """
+    user = user_factory()
+    api_rf.user = user
+
+    k1 = km_user_factory()
+    km_user_accessor_factory(
+        is_accepted=True,
+        km_user=k1,
+        user_with_access=user)
+
+    k2 = km_user_factory(user=user)
+
+    k3 = km_user_factory()
+    km_user_accessor_factory(
+        is_accepted=True,
+        km_user=k3,
+        user_with_access=user)
+
+    view = views.KMUserListView()
+    view.request = api_rf.get(url)
+
+    expected = [k2, k1, k3]
+
+    assert list(view.get_queryset()) == expected
+
+
 def test_get_shared(api_rf, km_user_accessor_factory, user_factory):
     """
     The list should include the users that the requesting user has


### PR DESCRIPTION
Closes #326

Modified the order of the queryset returned by the Know Me user list
view to return the KM User belonging to the requesting user first.