### PR TITLE
Fix accessor delete permissions.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ v1.1.0
 
 Features
   :issue:`346`: Add endpoint to list previously accepted accessors.
+  :issue:`347`: Allow users granted access by an accessor to delete that accessor.
 
 
 ******

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -404,6 +404,20 @@ class KMUserAccessor(mixins.IsAuthenticatedMixin, models.Model):
         """
         return request.user == self.user_with_access
 
+    def has_object_destroy_permission(self, request):
+        """
+        Check if the requesting user can destroy the accessor.
+
+        Args:
+            request:
+                The request to check permissions for.
+
+        Returns:
+            A boolean indicating if the requesting user has permission
+            to destroy the accessor.
+        """
+        return request.user in [self.km_user.user, self.user_with_access]
+
     def has_object_read_permission(self, request):
         """
         Check read permissions on the instance for a request.

--- a/km_api/know_me/tests/models/test_km_user_accessor_model.py
+++ b/km_api/know_me/tests/models/test_km_user_accessor_model.py
@@ -79,6 +79,51 @@ def test_has_object_accept_permission_owner(api_rf, km_user_accessor_factory):
     assert not accessor.has_object_accept_permission(request)
 
 
+def test_has_object_destroy_permission_accessee(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    The user granted access by the accessor should be able to delete the
+    accessor.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory(user_with_access=user)
+
+    api_rf.user = user
+    request = api_rf.get('/')
+
+    assert accessor.has_object_destroy_permission(request)
+
+
+def test_has_object_destroy_permission_other(
+        api_rf,
+        km_user_accessor_factory,
+        user_factory):
+    """
+    Other users should not be able to destroy a random accessor.
+    """
+    user = user_factory()
+    accessor = km_user_accessor_factory()
+
+    api_rf.user = user
+    request = api_rf.get('/')
+
+    assert not accessor.has_object_destroy_permission(request)
+
+
+def test_has_object_destroy_permission_owner(api_rf, km_user_accessor_factory):
+    """
+    The Know Me user the accessor grants access on should be able to
+    destroy the accessor.
+    """
+    accessor = km_user_accessor_factory()
+    api_rf.user = accessor.km_user.user
+    request = api_rf.get('/')
+
+    assert accessor.has_object_destroy_permission(request)
+
+
 def test_has_object_read_permission_accessee(
         api_rf,
         km_user_accessor_factory,

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -106,6 +106,7 @@ def test_serialize(
         'km_user_id': accessor.km_user.id,
         'permissions': {
             'accept': accessor.has_object_accept_permission(request),
+            'destroy': accessor.has_object_destroy_permission(request),
             'read': accessor.has_object_read_permission(request),
             'write': accessor.has_object_write_permission(request),
         },


### PR DESCRIPTION
Now both the user who created the accessor and the user granted access
by the accessor can destroy it.

<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #347