### PR TITLE
Fix duplicates in Know Me user list

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 
 
 ******
+v1.2.0
+******
+
+Bug Fixes
+  * :issue:`352`: Remove duplicate entry from user list.
+
+
+******
 v1.1.0
 ******
 

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -220,7 +220,7 @@ class KMUserListView(generics.ListAPIView):
         # Requesting user is the user
         filter_args |= Q(user=self.request.user)
 
-        query = models.KMUser.objects.filter(filter_args)
+        query = models.KMUser.objects.filter(filter_args).distinct()
 
         # Allow us to sort the query with the requesting user's Know Me
         # user first. See conditional expression documentation:


### PR DESCRIPTION
Closes #352

This bug had the same root cause as #343, so the fix was as simple as adding a `distinct()` call to the query.