### PR TITLE
Add Know Me user info to accessor response

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 v1.2.0
 ******
 
+Features
+  * :issue:`354`: Add Know Me user information to accessor response.
+
 Bug Fixes
   * :issue:`352`: Remove duplicate entry from user list.
 

--- a/km_api/know_me/serializers.py
+++ b/km_api/know_me/serializers.py
@@ -25,6 +25,19 @@ class ConfigSerializer(serializers.ModelSerializer):
         model = models.Config
 
 
+class KMUserInfoSerializer(serializers.ModelSerializer):
+    """
+    Serializer for displaying basic information about a Know Me user.
+
+    This serializer is used when we only need to display basic user
+    information, such as alongside an accessor.
+    """
+
+    class Meta:
+        fields = ('image', 'name')
+        model = models.KMUser
+
+
 class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for multiple ``KMUser`` instances.
@@ -113,6 +126,7 @@ class KMUserAccessorSerializer(serializers.HyperlinkedModelSerializer):
     """
     accept_url = serializers.HyperlinkedIdentityField(
         view_name='know-me:accessor-accept')
+    km_user = KMUserInfoSerializer(read_only=True)
     permissions = DRYPermissionsField(additional_actions=['accept'])
     url = serializers.HyperlinkedIdentityField(
         view_name='know-me:accessor-detail')
@@ -128,7 +142,7 @@ class KMUserAccessorSerializer(serializers.HyperlinkedModelSerializer):
             'email',
             'is_accepted',
             'is_admin',
-            'km_user_id',
+            'km_user',
             'permissions',
             'user_with_access')
         model = models.KMUserAccessor

--- a/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_accessor_serializer.py
@@ -85,6 +85,10 @@ def test_serialize(
         accessor,
         context={'request': request})
 
+    km_user_serializer = serializers.KMUserInfoSerializer(
+        km_user,
+        context={'request': request},
+    )
     user_serializer = UserInfoSerializer(
         accessor.user_with_access,
         context={'request': request})
@@ -103,7 +107,7 @@ def test_serialize(
         'email': accessor.email,
         'is_accepted': accessor.is_accepted,
         'is_admin': accessor.is_admin,
-        'km_user_id': accessor.km_user.id,
+        'km_user': km_user_serializer.data,
         'permissions': {
             'accept': accessor.has_object_accept_permission(request),
             'destroy': accessor.has_object_destroy_permission(request),

--- a/km_api/know_me/tests/serializers/test_km_user_info_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_info_serializer.py
@@ -1,0 +1,24 @@
+from know_me import serializers
+
+
+def test_serialize(api_rf, image, km_user_factory):
+    """
+    Test serializing a Know Me user.
+    """
+    km_user = km_user_factory(image=image)
+    request = api_rf.get(km_user.get_absolute_url())
+
+    serializer = serializers.KMUserInfoSerializer(
+        km_user,
+        context={'request': request},
+    )
+
+    image_request = api_rf.get(km_user.image.url)
+    image_url = image_request.build_absolute_uri()
+
+    expected = {
+        'image': image_url,
+        'name': km_user.name,
+    }
+
+    assert serializer.data == expected


### PR DESCRIPTION
Closes #354

The accessor serializer now includes the name and image of the Know Me user it grants access to.