### PR TITLE
Add email notifications for accessor invites.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 
 
 ******
+v1.3.0
+******
+
+Features
+  * :issue:`236`: Add email notifications when a user is invited to view another user's profiles.
+
+
+******
 v1.2.2
 ******
 

--- a/km_api/know_me/factories.py
+++ b/km_api/know_me/factories.py
@@ -18,6 +18,7 @@ class KMUserAccessorFactory(factory.django.DjangoModelFactory):
     """
     Factory for generating ``KMUserAccessor`` instances.
     """
+    email = factory.Sequence(lambda n: 'invite{n}@example.com'.format(n=n))
     km_user = factory.SubFactory('know_me.factories.KMUserFactory')
 
     class Meta(object):

--- a/km_api/know_me/templates/know_me/emails/invite.txt
+++ b/km_api/know_me/templates/know_me/emails/invite.txt
@@ -1,0 +1,15 @@
+{% load i18n %}{% blocktrans %}You have been invited to learn more about {{ name }} with the Know Me iOS app. Please use this email address to log into Know Me and view your invitation.
+
+
+Don't have Know Me? No Problem. You can download the app for free from the app store:
+
+https://itunes.apple.com/us/app/know-me-profile-communication/id1051805757?mt=8
+
+
+Thanks,
+The Know Me Team
+
+
+
+Replies to this email address are not monitored. If you would like to contact us, please send an email to team@knowmetools.com.
+{% endblocktrans %}


### PR DESCRIPTION
Closes #236

When a Know Me user is shared through the creation of an accessor, the
user who the accessor grants access to is sent an email notification.