### PR TITLE
Add is_premium_user property to Know Me users.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ In Development
 Features
   * :issue:`382`: Verify Apple receipts using the Apple store's receipt validation service.
   * :issue:`397`: Ensure Apple receipts are unique (i.e. multiple people can't use the same receipt).
+  * :issue:`399`: Add ``is_premium_user`` property to Know Me user response.
 
 
 ******

--- a/km_api/conftest.py
+++ b/km_api/conftest.py
@@ -15,7 +15,11 @@ from rest_framework.test import APIClient, APIRequestFactory
 
 import factories
 import test_utils
-from know_me.factories import SubscriptionAppleDataFactory
+from know_me.factories import (
+    SubscriptionAppleDataFactory,
+    KMUserFactory,
+    SubscriptionFactory,
+)
 from test_utils.apple_receipt_validator import (
     apple_validator_app,
     AppleReceiptValidationClient,
@@ -200,6 +204,17 @@ def image():
     return ContentFile(content=out_stream.getvalue(), name="foo.png")
 
 
+@pytest.fixture
+def km_user_factory(db):
+    """
+    Fixture to get the factory used to create a Know Me User.
+
+    Returns:
+        The factory class used to create test ``KMUser`` instances.
+    """
+    return KMUserFactory
+
+
 @pytest.fixture(scope="session")
 def serialized_time():
     """
@@ -221,6 +236,14 @@ def serializer_context(api_rf):
             A dictionary containing dummy context for serializers.
     """
     return {"request": api_rf.get("/")}
+
+
+@pytest.fixture
+def subscription_factory(db):
+    """
+    Fixture to get the factory used to create subscriptions.
+    """
+    return SubscriptionFactory
 
 
 @pytest.fixture

--- a/km_api/functional_tests/know_me/users/test_list_know_me_users.py
+++ b/km_api/functional_tests/know_me/users/test_list_know_me_users.py
@@ -1,0 +1,30 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+
+@pytest.mark.parametrize("is_premium", [True, False])
+def test_km_user_premium_flag(
+    api_client, is_premium, km_user_factory, subscription_factory
+):
+    """
+    The response from the Know Me user list should include a boolean
+    property indicating if each user is a premium user.
+    """
+    # Given a Know Me user...
+    password = "password"
+    km_user = km_user_factory(user__password=password)
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # ...who may have a subscription...
+    if is_premium:
+        subscription_factory(is_active=True, user=km_user.user)
+
+    # If they list all Know Me users...
+    url = reverse("know-me:km-user-list")
+    response = api_client.get(url)
+
+    # The response should indicate if the Know Me user is a premium
+    # user.
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()[0]["is_premium_user"] == is_premium

--- a/km_api/know_me/conftest.py
+++ b/km_api/know_me/conftest.py
@@ -42,27 +42,8 @@ def km_user_accessor_factory(db):
 
 
 @pytest.fixture
-def km_user_factory(db):
-    """
-    Fixture to get the factory used to create a Know Me User.
-
-    Returns:
-        The factory class used to create test ``KMUser`` instances.
-    """
-    return factories.KMUserFactory
-
-
-@pytest.fixture
 def legacy_user_factory(db):
     """
     Fixture to get the factory used to create legacy users.
     """
     return factories.LegacyUserFactory
-
-
-@pytest.fixture
-def subscription_factory(db):
-    """
-    Fixture to get the factory used to create subscriptions.
-    """
-    return factories.SubscriptionFactory

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -266,6 +266,17 @@ class KMUser(mixins.IsAuthenticatedMixin, models.Model):
             is_accepted=True, is_admin=True, user_with_access=request.user
         ).exists()
 
+    @property
+    def is_premium_user(self):
+        """
+        Returns:
+            A boolean indicating if the Know Me user has an active
+            premium subscription.
+        """
+        return Subscription.objects.filter(
+            is_active=True, user=self.user
+        ).exists()
+
     def share(self, email, is_admin=False):
         """
         Share a Know Me account with another user.

--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -44,6 +44,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
     Serializer for multiple ``KMUser`` instances.
     """
 
+    is_premium_user = serializers.BooleanField(read_only=True)
     is_owned_by_current_user = serializers.SerializerMethodField()
     journal_entries_url = serializers.HyperlinkedIdentityField(
         view_name="know-me:journal:entry-list"
@@ -70,7 +71,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             },
             "quote": {
                 "help_text": (
-                    "A quote for the Know Me user to introduce " "themself."
+                    "A quote for the Know Me user to introduce themself."
                 )
             },
         }
@@ -79,6 +80,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             "url",
             "created_at",
             "updated_at",
+            "is_premium_user",
             "is_owned_by_current_user",
             "image",
             "journal_entries_url",

--- a/km_api/know_me/tests/models/test_km_user_model.py
+++ b/km_api/know_me/tests/models/test_km_user_model.py
@@ -233,6 +233,42 @@ def test_has_object_write_permission_shared_not_accepted(
     assert not km_user.has_object_write_permission(request)
 
 
+def test_is_premium_user_no_subscription(km_user_factory):
+    """
+    If the Know Me user does not have an associated subscription
+    instance, they should not be a premium user.
+    """
+    km_user = km_user_factory()
+
+    assert not km_user.is_premium_user
+
+
+def test_is_premium_user_inactive_subscription(
+    km_user_factory, subscription_factory
+):
+    """
+    If the subscription associated with a Know Me user is inactive, that
+    user should not be a premium user.
+    """
+    km_user = km_user_factory()
+    subscription_factory(is_active=False, user=km_user.user)
+
+    assert not km_user.is_premium_user
+
+
+def test_is_premium_user_with_subscription(
+    km_user_factory, subscription_factory
+):
+    """
+    If the Know Me user has an associated active subscription, they
+    should be a premium user.
+    """
+    km_user = km_user_factory()
+    subscription_factory(is_active=True, user=km_user.user)
+
+    assert km_user.is_premium_user
+
+
 def test_name(km_user_factory):
     """
     The know me user's name property should return the associated user's

--- a/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
@@ -85,6 +85,7 @@ def test_serialize(
         "created_at": serialized_time(km_user.created_at),
         "updated_at": serialized_time(km_user.updated_at),
         "image": image_url,
+        "is_premium_user": km_user.is_premium_user,
         "is_owned_by_current_user": km_user.user == request.user,
         "journal_entries_url": entries_url,
         "media_resource_categories_url": categories_url,


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #399


### Proposed Changes

This PR adds an `is_premium_user` property to the serialized response for Know Me users.
