### PR TITLE
Create app db user role during migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
 
 # Install Dependencies
-RUN apk add --no-cache build-base libjpeg-turbo-dev postgresql-dev zlib-dev
+RUN apk add --no-cache build-base libjpeg-turbo-dev postgresql-client postgresql-dev zlib-dev
 RUN pip install --upgrade pip pipenv
 
 # Copy application

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,7 @@ create_db_user() {
 	)
 
     export PGPASSWORD=${DATABASE_ADMIN_PASSWORD}
-	psql --host ${DJANGO_DB_HOST} --port ${DJANGO_DB_PORT} --user ${DATABASE_ADMIN_USER} --dbname ${DJANGO_DB_NAME} < ${CREATE_ROLE}
+	echo ${CREATE_ROLE} | psql --host ${DJANGO_DB_HOST} --port ${DJANGO_DB_PORT} --user ${DATABASE_ADMIN_USER} --dbname ${DJANGO_DB_NAME}
 }
 
 if [[ "$1" = 'migrate' ]]; then


### PR DESCRIPTION
Create the database role used by the application within the `migrate` command. This simplifies the requirements for deploying the application because we no longer need to connect to the database and add the role during the provisioning process.