### PR TITLE
Downgrade log level of invalid product message.

### DIFF
--- a/km_api/know_me/subscriptions.py
+++ b/km_api/know_me/subscriptions.py
@@ -247,7 +247,7 @@ def validate_apple_receipt_response(receipt_response):
     product = latest_receipt.get("product_id")
 
     if product not in settings.APPLE_PRODUCT_CODES["KNOW_ME_PREMIUM"]:
-        logger.warning(
+        logger.info(
             "Received receipt that included a transaction for the unknown "
             'product "%s"',
             product,


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #424


### Proposed Changes

If we receive an Apple receipt for an unknown product, the log message
that is produced is now of level `INFO` rather than `WARNING`.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
