### PR TITLE
Mark apple receipt expiration time as read only

### DIFF
--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -24,6 +24,7 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
             "receipt_data",
         )
         model = models.SubscriptionAppleData
+        read_only_fields = ("expiration_time",)
 
     def validate(self, data):
         """


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #421


### Proposed Changes

Mark the Apple receipt expiration time field as read only so it does not appear as a parameter in the documentation.