### PR TITLE
Only list shared Know Me users with premium.

### DIFF
--- a/km_api/conftest.py
+++ b/km_api/conftest.py
@@ -16,6 +16,7 @@ from rest_framework.test import APIClient, APIRequestFactory
 import factories
 import test_utils
 from know_me.factories import (
+    KMUserAccessorFactory,
     KMUserFactory,
     SubscriptionAppleDataFactory,
     SubscriptionFactory,
@@ -212,6 +213,17 @@ def image():
     image.save(out_stream, format="png")
 
     return ContentFile(content=out_stream.getvalue(), name="foo.png")
+
+
+@pytest.fixture
+def km_user_accessor_factory(db):
+    """
+    Fixture to get the factory used to create km user accessors.
+
+    Returns:
+        The factory class used to create ``KMUser Access`` instances.
+    """
+    return KMUserAccessorFactory
 
 
 @pytest.fixture

--- a/km_api/functional_tests/know_me/users/test_list_know_me_users.py
+++ b/km_api/functional_tests/know_me/users/test_list_know_me_users.py
@@ -1,30 +1,141 @@
 import pytest
 from rest_framework import status
-from rest_framework.reverse import reverse
+
+from functional_tests import serialization_helpers
+
+LIST_URL = "/know-me/users/"
 
 
 @pytest.mark.parametrize("is_premium", [True, False])
-def test_km_user_premium_flag(
-    api_client, is_premium, km_user_factory, subscription_factory
-):
+def test_km_user_premium_flag(api_client, is_premium, km_user_factory):
     """
     The response from the Know Me user list should include a boolean
     property indicating if each user is a premium user.
     """
     # Given a Know Me user...
     password = "password"
-    km_user = km_user_factory(user__password=password)
+    km_user = km_user_factory(
+        user__has_premium=is_premium, user__password=password
+    )
     api_client.log_in(km_user.user.primary_email.email, password)
 
-    # ...who may have a subscription...
-    if is_premium:
-        subscription_factory(is_active=True, user=km_user.user)
-
     # If they list all Know Me users...
-    url = reverse("know-me:km-user-list")
-    response = api_client.get(url)
+    response = api_client.get(LIST_URL)
 
     # The response should indicate if the Know Me user is a premium
     # user.
     assert response.status_code == status.HTTP_200_OK
     assert response.json()[0]["is_premium_user"] == is_premium
+
+
+def test_list_anonymous(api_client):
+    """
+    Anonymous users should receive a 403 response.
+    """
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_list_own_first(
+    api_client, km_user_accessor_factory, km_user_factory, user_factory
+):
+    """
+    If the requesting user has a Know Me user and is granted access to
+    additional Know Me users via accessors, the user's own Know Me user
+    should be listed first.
+    """
+    # Given an existing user...
+    password = "password"
+    user = user_factory(password=password)
+    api_client.log_in(user.primary_email.email, password)
+
+    # ...who is granted access to another user...
+    accessor = km_user_accessor_factory(
+        is_accepted=True,
+        km_user__user__has_premium=True,
+        user_with_access=user,
+    )
+
+    # ...and has their own Know Me user...
+    km_user = km_user_factory(user=user)
+
+    # ...then when they list the users they have access to, their own
+    # user should be listed first.
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == serialization_helpers.km_user_list(
+        [km_user, accessor.km_user],
+        lambda km: km.user == user,
+        api_client.build_full_url,
+    )
+
+
+def test_list_own_no_premium(api_client, km_user_factory):
+    """
+    If a user does not have premium, the list should still include their
+    own Know Me user.
+    """
+    # Given an existing Know Me user...
+    password = "password"
+    km_user = km_user_factory(user__password=password)
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # ...they should be able to list their own Know Me user
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == serialization_helpers.km_user_list(
+        [km_user],
+        # All users are owned by the requesting user.
+        lambda _: True,
+        api_client.build_full_url,
+    )
+
+
+def test_list_shared_with_premium(
+    api_client, km_user_accessor_factory, user_factory
+):
+    """
+    If the requesting user has been granted access to another profile
+    and the profile's owner has an active premium subscription, the user
+    should be listed.
+    """
+    password = "password"
+    user = user_factory(password="password")
+    accessor = km_user_accessor_factory(
+        is_accepted=True,
+        km_user__user__has_premium=True,
+        user_with_access=user,
+    )
+
+    api_client.log_in(user.primary_email.email, password)
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == serialization_helpers.km_user_list(
+        [accessor.km_user],
+        # None of the users are owned by the requesting user
+        lambda _: False,
+        api_client.build_full_url,
+    )
+
+
+def test_list_shared_without_premium(
+    api_client, km_user_accessor_factory, user_factory
+):
+    """
+    If a user has access to a profile through an accessor but the
+    profile's owner does not have an active premium subscription, the
+    shared user should not be listed.
+    """
+    password = "password"
+    user = user_factory(password="password")
+    km_user_accessor_factory(is_accepted=True, user_with_access=user)
+
+    api_client.log_in(user.primary_email.email, password)
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []

--- a/km_api/functional_tests/serialization_helpers.py
+++ b/km_api/functional_tests/serialization_helpers.py
@@ -7,6 +7,73 @@ object type, but we want to maintain a clear separation of the codebase
 and these functional tests. Having to change the serialization here
 indicates that a potentially breaking change was made.
 """
+from test_utils import serialized_time
+
+
+def build_full_file_url(file_field, build_full_url):
+    """
+    Build the full URL for a file field.
+
+    Args:
+        file_field:
+            The file field to build the full URL for.
+        build_full_url:
+            The function used to build a full URL out of an absolute
+            path.
+
+    Returns:
+        The full URL to the file contained in the given field if it
+        exists. If the field is empty, ``None`` is returned instead.
+    """
+    return build_full_url(file_field.url) if file_field else None
+
+
+def km_user_list(km_users, is_owned_by_user, build_full_url):
+    """
+    Get the serialized version of a list of Know Me users.
+
+    Args:
+        km_users:
+            The users to serialize.
+        is_owned_by_user:
+            A function that returns a boolean indicating if a given user
+            is owned by the "current" user.
+        build_full_url:
+            A function used to take an absolute path and turn it into a
+            full URL.
+
+    Returns:
+        A list containing the serialized version of each Know Me user.
+    """
+
+    def serialize(user):
+        return {
+            "id": user.pk,
+            "url": build_full_url(f"/know-me/users/{user.pk}/"),
+            "created_at": serialized_time(user.created_at),
+            "updated_at": serialized_time(user.updated_at),
+            "is_premium_user": user.is_premium_user,
+            "is_owned_by_current_user": is_owned_by_user(user),
+            "image": build_full_file_url(user.image, build_full_url),
+            "journal_entries_url": build_full_url(
+                f"/know-me/users/{user.pk}/journal-entries/"
+            ),
+            "media_resource_categories_url": build_full_url(
+                f"/know-me/users/{user.pk}/media-resource-categories/"
+            ),
+            "media_resources_url": build_full_url(
+                f"/know-me/users/{user.pk}/media-resources/"
+            ),
+            "name": user.name,
+            "permissions": {"read": True, "write": is_owned_by_user(user)},
+            "profiles_url": build_full_url(
+                f"/know-me/users/{user.pk}/profiles/"
+            ),
+            "quote": user.quote,
+            "user_image": build_full_file_url(user.user.image, build_full_url),
+        }
+
+    return list(map(serialize, km_users))
 
 
 def user_info(user):

--- a/km_api/know_me/conftest.py
+++ b/km_api/know_me/conftest.py
@@ -31,17 +31,6 @@ def file():
 
 
 @pytest.fixture
-def km_user_accessor_factory(db):
-    """
-    Fixture to get the factory used to create km user accessors.
-
-    Returns:
-        The factory class used to create ``KMUser Access`` instances.
-    """
-    return factories.KMUserAccessorFactory
-
-
-@pytest.fixture
 def legacy_user_factory(db):
     """
     Fixture to get the factory used to create legacy users.

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -271,9 +271,14 @@ class KMUserListView(generics.ListAPIView):
             A queryset containing the ``KMUser`` instances accessible to
             the requesting user.
         """
-        # User granted access through an accessor
-        filter_args = Q(km_user_accessor__user_with_access=self.request.user)
-        filter_args &= Q(km_user_accessor__is_accepted=True)
+        # User granted access through an accessor. Note that the owner
+        # of the Know Me user being shared must have an active premium
+        # subscription.
+        filter_args = Q(km_user_accessor__is_accepted=True)
+        filter_args &= Q(
+            km_user_accessor__km_user__user__know_me_subscription__is_active=True  # noqa
+        )
+        filter_args &= Q(km_user_accessor__user_with_access=self.request.user)
 
         # Requesting user is the user
         filter_args |= Q(user=self.request.user)


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #402


### Proposed Changes

When listing Know Me users that the requesting user has access to, the only shared users that are returned are the ones who have an active premium subscription. The requesting user's Know Me user is returned regardless of subscription status.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
