### PR TITLE
Require premium to list/add followers

### DIFF
--- a/km_api/functional_tests/know_me/accessors/test_create_accessor.py
+++ b/km_api/functional_tests/know_me/accessors/test_create_accessor.py
@@ -1,0 +1,58 @@
+from rest_framework import status
+
+
+URL = "/know-me/users/accessors/"
+
+
+def test_create_anonymous(api_client, km_user_factory):
+    """
+    Anonymous users should receive a 403 response if they try to create
+    an accessor.
+    """
+    response = api_client.post(URL, {"email": "test@example.com"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_create_as_non_premium_user(api_client, km_user_factory):
+    """
+    Non-premium users should receive a 403 response if they try to add a
+    new accessor.
+    """
+    # If Iris is a non-premium user...
+    password = "password"
+    km_user = km_user_factory(
+        user__first_name="Iris",
+        user__has_premium=False,
+        user__password="password",
+    )
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # ...and she attempts to add an accessor, then she should receive a
+    # permission denied error.
+    data = {"email": "share@example.com"}
+    response = api_client.post(URL, data)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_create_as_premium_user(api_client, km_user_factory):
+    """
+    Premium users should be able to create accessors to share their
+    Know Me user with others.
+    """
+    # Assume Barry is an existing user with a premium subscription.
+    password = "password"
+    km_user = km_user_factory(
+        user__first_name="Barry",
+        user__has_premium=True,
+        user__password=password,
+    )
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # He should be able to share his account with another user.
+    data = {"email": "share@example.com"}
+    response = api_client.post(URL, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["email"] == data["email"]

--- a/km_api/functional_tests/know_me/accessors/test_list_accessors.py
+++ b/km_api/functional_tests/know_me/accessors/test_list_accessors.py
@@ -1,0 +1,73 @@
+from rest_framework import status
+
+from functional_tests import serialization_helpers
+
+
+URL = "/know-me/users/accessors/"
+
+
+def test_list_anonymous(api_client):
+    """
+    If an anonymous user attempts to access the view, they should
+    receive a 403 response.
+
+    Regression test for #325
+    """
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_list_accessors(
+    api_client, km_user_accessor_factory, km_user_factory, user_factory
+):
+    """
+    If an authenticated user accesses this endpoint, it should list all
+    the accessors granting access to their Know Me user.
+    """
+    # Given an existing Know Me user...
+    password = "password"
+    km_user = km_user_factory(user__has_premium=True, user__password=password)
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # ...and some accessors granting access to that user...
+    accessor1 = km_user_accessor_factory(is_accepted=True, km_user=km_user)
+    accessor2 = km_user_accessor_factory(
+        is_accepted=False, km_user=km_user, user_with_access=user_factory()
+    )
+
+    # ...then the accessor list view should list those accessors.
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == list(
+        map(
+            lambda accessor: serialization_helpers.km_user_accessor(
+                accessor, api_client.build_full_url
+            ),
+            [accessor1, accessor2],
+        )
+    )
+
+
+def test_list_accessors_non_premium(api_client, km_user_factory):
+    """
+    If a user does not have a premium subscription, they should receive
+    a 403 response if they try to list the accessors granting access to
+    their account.
+    """
+    # Given John is an existing Know Me user without a premium
+    # subscription...
+    password = "password"
+    km_user = km_user_factory(
+        user__first_name="John",
+        user__has_premium=False,
+        user__password=password,
+    )
+    api_client.log_in(km_user.user.primary_email.email, password)
+
+    # ...then he should receive a 403 response if he tries to list the
+    # accessors granting access to his account.
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/km_api/functional_tests/serialization_helpers.py
+++ b/km_api/functional_tests/serialization_helpers.py
@@ -10,6 +10,47 @@ indicates that a potentially breaking change was made.
 from test_utils import serialized_time
 
 
+def _has_destroy_perm(_):
+    return False
+
+
+def _is_owner(_):
+    return True
+
+
+def km_user_accessor(
+    accessor,
+    build_full_url,
+    has_destroy_perm=_has_destroy_perm,
+    is_owner=_is_owner,
+):
+    return {
+        "id": accessor.pk,
+        "url": build_full_url(f"/know-me/accessors/{accessor.pk}/"),
+        "created_at": serialized_time(accessor.created_at),
+        "updated_at": serialized_time(accessor.updated_at),
+        "accept_url": build_full_url(
+            f"/know-me/accessors/{accessor.pk}/accept/"
+        ),
+        "email": accessor.email,
+        "is_accepted": accessor.is_accepted,
+        "is_admin": accessor.is_admin,
+        "km_user": {
+            "image": build_full_file_url(
+                accessor.km_user.image, build_full_url
+            ),
+            "name": accessor.km_user.name,
+        },
+        "permissions": {
+            "accept": has_destroy_perm(accessor),
+            "destroy": is_owner(accessor),
+            "read": is_owner(accessor),
+            "write": is_owner(accessor),
+        },
+        "user_with_access": user_info(accessor.user_with_access),
+    }
+
+
 def build_full_file_url(file_field, build_full_url):
     """
     Build the full URL for a file field.
@@ -88,6 +129,9 @@ def user_info(user):
         A dictionary containing the serialized representation of the
         given user's information.
     """
+    if not user:
+        return None
+
     return {
         "first_name": user.first_name,
         "image": None,

--- a/km_api/know_me/permissions.py
+++ b/km_api/know_me/permissions.py
@@ -49,6 +49,35 @@ class HasKMUserAccess(permissions.IsAuthenticated):
         return request.method in permissions.SAFE_METHODS
 
 
+class HasPremium(permissions.IsAuthenticated):
+    """
+    Permission class to ensure the requesting user has an active Know Me
+    premium subscription.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Determine if the requesting user has an active premium
+        subscription.
+
+        Args:
+            request:
+                The request being made.
+            view:
+                The view being accessed.
+
+        Returns:
+            A boolean indicating if the requesting user has an active
+            premium subscription.
+        """
+        if not super().has_permission(request, view):
+            return False
+
+        return models.Subscription.objects.filter(
+            is_active=True, user=request.user
+        ).exists()
+
+
 class OwnerHasPremium(permissions.BasePermission):
     """
     Permission class to ensure the owner of some object or collection

--- a/km_api/know_me/tests/permissions/test_has_premium.py
+++ b/km_api/know_me/tests/permissions/test_has_premium.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+from know_me.permissions import HasPremium
+
+
+def test_has_permission_active_subscription(api_rf, user_factory):
+    """
+    If the requesting user has an active premium subscription, the
+    permission should return ``True``.
+    """
+    user = user_factory(has_premium=True)
+    api_rf.user = user
+
+    request = api_rf.get("/")
+    view = mock.Mock(name="Mock View")
+
+    perm = HasPremium()
+
+    assert perm.has_permission(request, view)
+
+
+def test_has_permission_anonymous(api_rf):
+    """
+    If the requesting user is anonymous, permission should be denied.
+    """
+    request = api_rf.get("/")
+    view = mock.Mock(name="Mock View")
+
+    perm = HasPremium()
+
+    assert not perm.has_permission(request, view)
+
+
+def test_has_permission_inactive_subscription(
+    api_rf, user_factory, subscription_factory
+):
+    """
+    If the requesting user has an inactive subscription, permission
+    should be denied.
+    """
+    user = user_factory()
+    subscription_factory(is_active=False, user=user)
+    api_rf.user = user
+
+    request = api_rf.get("/")
+    view = mock.Mock(name="Mock View")
+
+    perm = HasPremium()
+
+    assert not perm.has_permission(request, view)
+
+
+def test_has_permission_no_subscription(api_rf, user_factory):
+    """
+    If there is no subscription data associated with the requesting user
+    then permission should be denied.
+    """
+    user = user_factory()
+    api_rf.user = user
+
+    request = api_rf.get("/")
+    view = mock.Mock(name="Mock View")
+
+    perm = HasPremium()
+
+    assert not perm.has_permission(request, view)

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -7,7 +7,7 @@ from dry_rest_permissions.generics import DRYGlobalPermissions, DRYPermissions
 from rest_framework import generics, pagination, status
 from rest_framework.response import Response
 
-from know_me import models, serializers
+from know_me import models, serializers, permissions
 from know_me.serializers import subscription_serializers
 from permission_utils.view_mixins import DocumentActionMixin
 
@@ -165,12 +165,18 @@ class AccessorListView(generics.ListCreateAPIView):
     Endpoint for listing the accessors that grant access to the current
     user's Know Me profiles.
 
+    *__Note:__ The requesting user must have an active premium
+    subscription to access this view.*
+
     post:
     Endpoint for creating a new accessor for the current user's
     profiles.
+
+    *__Note:__ The requesting user must have an active premium
+    subscription to access this view.*
     """
 
-    permission_classes = (DRYPermissions,)
+    permission_classes = (DRYPermissions, permissions.HasPremium)
     serializer_class = serializers.KMUserAccessorSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #419 


### Proposed Changes

In order to list or add accessors granting others access to their profile, a user must have an active premium subscription.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
