### PR TITLE
Include more source files in coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,10 @@
 [run]
 branch = True
 omit = \
+    */functional_tests/*,
+    */migrations/*,
     */test_utils/*,
     */test/*,
     */tests/*,
-    km_api/manage.py,
-    km_api/km_api/wsgi.py,
-    */migrations/*,
-    */admin.py,
-    km_api/functional_tests/*,
-    km_api/km_api/*
+    */manage.py
 source = km_api


### PR DESCRIPTION
Just because it is difficult to test some things doesn't mean they should not be included in the coverage report.