### PR TITLE
Add endpoint for transferring a subscription

### DIFF
--- a/km_api/factories.py
+++ b/km_api/factories.py
@@ -5,6 +5,7 @@ These factories are used project-wide.
 
 import factory
 from django.contrib.auth import get_user_model
+from rest_email_auth.signals import user_registered
 
 
 class EmailConfirmationFactory(factory.DjangoModelFactory):
@@ -83,3 +84,10 @@ class UserFactory(factory.django.DjangoModelFactory):
         manager = cls._get_manager(model_class)
 
         return manager.create_user(*args, **kwargs)
+
+    @factory.post_generation
+    def registration_signal(obj, create, extracted, **kwargs):
+        if not create or not kwargs.get("send", False):
+            return
+
+        user_registered.send(sender=UserFactory, user=obj)

--- a/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
@@ -1,0 +1,167 @@
+from rest_framework import status
+
+TRANSFER_URL = "/know-me/subscription/transfer/"
+
+
+def user_is_premium(api_client):
+    """
+    Determine if the user logged in to the API client has a premium
+    subscription.
+
+    Args:
+        api_client:
+            The client to use to determine premium status.
+
+    Returns:
+        A boolean indicating if the user is a premium user.
+    """
+    response = api_client.get("/know-me/users/")
+    response.raise_for_status()
+
+    return response.json()[0]["is_premium_user"]
+
+
+def test_transfer_anonymous(api_client):
+    """
+    Anonymous users should receive a 403 response if they attempt to
+    initiate a transfer.
+    """
+    response = api_client.post(
+        TRANSFER_URL, {"recipient_url": "fake@example.com"}
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_transfer_initiator_no_premium(
+    api_client, subscription_factory, user_factory
+):
+    """
+    If the user initiating the transfer does not have an active premium
+    subscription, a 403 response should be returned.
+    """
+    # Assume Shawn and Juliet are two existing users, neither of whom
+    # have premium subscriptions.
+    password = "password"
+    user1 = user_factory(first_name="Shawn", password=password)
+    user2 = user_factory(first_name="Juliet", password=password)
+    subscription_factory(is_active=False, user=user1)
+
+    # If Shawn attempts to transfer his inactive subscription to Juliet,
+    # he should receive a 403 response.
+    api_client.log_in(user1.primary_email.email, password)
+    response = api_client.post(
+        TRANSFER_URL, {"recipient_email": user2.primary_email.email}
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_transfer_recipient_active_subscription(
+    api_client, subscription_factory, user_factory
+):
+    """
+    If the intended recipient has an active subscription, the transfer
+    request should fail.
+    """
+    # Assume Shawn and Juliet are two existing users, both with active
+    # premium subscriptions.
+    password = "password"
+    user1 = user_factory(
+        first_name="Shawn", has_premium=True, password=password
+    )
+    user2 = user_factory(
+        first_name="Shawn", has_premium=True, password=password
+    )
+
+    # If Shawn tries to transfer his premium subscription to Juliet, he
+    # should receive an error because Juliet already has a subscription.
+    api_client.log_in(user1.primary_email.email, password)
+    response = api_client.post(
+        TRANSFER_URL, {"recipient_email": user2.primary_email.email}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "non_field_errors": [
+            "The intended recipient already has an active premium "
+            "subscription."
+        ]
+    }
+
+
+def test_transfer_recipient_apple_data(
+    api_client, apple_subscription_factory, user_factory
+):
+    """
+    If the intended recipient has an Apple receipt associated with their
+    account, they should not be able to receive a subscription transfer,
+    even if their subscription is inactive.
+    """
+    # Assume Shawn is an existing user with an active premium
+    # subscription...
+    password = "password"
+    user1 = user_factory(
+        first_name="Shawn", has_premium=True, password=password
+    )
+
+    # ...and Juliet is a user with an inactive premium subscription but
+    # who has an Apple receipt tied to her account.
+    user2 = user_factory(first_name="Juliet", password=password)
+    apple_subscription_factory(
+        subscription__is_active=False, subscription__user=user2
+    )
+
+    # If Shawn tries to transfer his premium subscription to Juliet, the
+    # transfer should fail.
+    api_client.log_in(user1.primary_email.email, password)
+    response = api_client.post(
+        TRANSFER_URL, {"recipient_email": user2.primary_email.email}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "non_field_errors": [
+            "The intended recipient has an Apple subscription that must be "
+            "removed before they can accept a transfer."
+        ]
+    }
+
+
+def test_transfer_recipient_no_subscription(
+    api_client, subscription_factory, user_factory
+):
+    """
+    If we have two users, one who has an active subscription and one who
+    does not, the user with the active subscription should be able to
+    transfer their subscription to the user without one.
+    """
+    # Assume Shawn and Juliet are two existing users. Shawn has an
+    # active premium subscription.
+    password = "password"
+    user1 = user_factory(
+        first_name="Shawn",
+        has_premium=True,
+        password=password,
+        registration_signal__send=True,
+    )
+    user2 = user_factory(
+        first_name="Juliet", password=password, registration_signal__send=True
+    )
+
+    # If Shawn logs in, he should be able to transfer his subscription
+    # to Juliet.
+    api_client.log_in(user1.primary_email.email, password)
+    transfer_response = api_client.post(
+        TRANSFER_URL, {"recipient_email": user2.primary_email.email}
+    )
+
+    assert transfer_response.status_code == status.HTTP_201_CREATED
+
+    # Shawn should no longer be a premium user.
+    assert not user_is_premium(api_client)
+
+    # Juliet should be a premium user.
+    api_client.log_in(user2.primary_email.email, password)
+
+    assert user_is_premium(api_client)

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -1,7 +1,9 @@
 import hashlib
 import logging
 
-from django.utils.translation import ugettext
+from django.db import transaction
+from django.utils.translation import ugettext, ugettext_lazy as _
+from rest_email_auth.models import EmailAddress
 from rest_framework import serializers
 
 from know_me import models, subscriptions
@@ -63,3 +65,123 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
         validated_data["expiration_time"] = receipt.expires_date
 
         return validated_data
+
+
+class SubscriptionTransferSerializer(serializers.Serializer):
+    """
+    Serializer for transferring a Know Me premium subscription to a
+    different user.
+    """
+
+    recipient_email = serializers.EmailField(
+        help_text=_(
+            "The email address of the Know Me user that the requesting user's "
+            "premium subscription should be transferred to."
+        )
+    )
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize cached values to ``None``.
+        """
+        super().__init__(*args, **kwargs)
+
+        self._recipient_email_inst = None
+
+    def save(self):
+        """
+        Transfer a subscription to the user who owns the provided email
+        address.
+        """
+        owner = self.context["request"].user
+        recipient = self._recipient_email_inst.user
+
+        logger.info(
+            "Transferring subscription %r from user %r to user %r",
+            owner.know_me_subscription,
+            owner.pk,
+            recipient.pk,
+        )
+
+        with transaction.atomic():
+            models.Subscription.objects.filter(user=recipient).delete()
+            models.Subscription.objects.filter(user=owner).update(
+                user=recipient
+            )
+
+    def validate(self, data):
+        """
+        Validate the transfer request as a whole.
+
+        Args:
+            data:
+                The data to validate.
+
+        Returns:
+            The validated data.
+
+        Raises:
+            serializers.ValidationError:
+                If the recipient is unable to receive a subscription
+                transfer.
+        """
+        if not models.Subscription.objects.filter(
+            is_active=True, user=self.context["request"].user
+        ).exists():
+            raise serializers.ValidationError(
+                ugettext(
+                    "You must have an active premium subscription in order to "
+                    "transfer it to another user."
+                )
+            )
+
+        if models.Subscription.objects.filter(
+            is_active=True, user=self._recipient_email_inst.user
+        ).exists():
+            raise serializers.ValidationError(
+                ugettext(
+                    "The intended recipient already has an active premium "
+                    "subscription."
+                )
+            )
+
+        if models.SubscriptionAppleData.objects.filter(
+            subscription__user=self._recipient_email_inst.user
+        ).exists():
+            raise serializers.ValidationError(
+                ugettext(
+                    "The intended recipient has an Apple subscription that "
+                    "must be removed before they can accept a transfer."
+                )
+            )
+
+        return data
+
+    def validate_recipient_email(self, email):
+        """
+        Validate the recipient's email address.
+
+        Args:
+            email:
+                The email address to validate.
+
+        Returns:
+            The validated email address.
+
+        Raises:
+            serializers.ValidationError:
+                If the provided email address does not exist or is not
+                verified.
+        """
+        email_query = EmailAddress.objects.filter(
+            email=email, is_verified=True
+        )
+
+        if not email_query.exists():
+            raise serializers.ValidationError(
+                ugettext("No Know Me user owns the provided email address.")
+            )
+
+        self._recipient_email_inst = email_query.get()
+
+        return email

--- a/km_api/know_me/tests/serializers/test_subscription_transfer_serializer.py
+++ b/km_api/know_me/tests/serializers/test_subscription_transfer_serializer.py
@@ -1,0 +1,184 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from know_me import models
+from know_me.serializers import subscription_serializers
+
+
+def test_save(api_rf, subscription_factory, user_factory):
+    """
+    Given a user with an active subscription and the email address of a
+    user without an active subscription, saving the serializer should
+    transfer the subscription between the two users.
+    """
+    subscription = subscription_factory(is_active=True)
+    user = subscription.user
+    request = api_rf.get("/")
+    request.user = user
+    recipient = user_factory()
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": request},
+        data={"recipient_email": recipient.primary_email.email},
+    )
+    assert serializer.is_valid()
+
+    serializer.save()
+    user.refresh_from_db()
+    recipient.refresh_from_db()
+
+    assert not hasattr(user, "know_me_subscription")
+    assert recipient.know_me_subscription == subscription
+
+
+def test_save_recipient_inactive_subscription(
+    api_rf, subscription_factory, user_factory
+):
+    """
+    If the recipient has an inactive subscription, it should be deleted
+    during the transfer process.
+    """
+    subscription = subscription_factory(is_active=True)
+    user = subscription.user
+    api_rf.user = user
+    request = api_rf.get("/")
+
+    recipient = user_factory()
+    recipient_subscription = subscription_factory(
+        is_active=False, user=recipient
+    )
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": request},
+        data={"recipient_email": recipient.primary_email.email},
+    )
+    assert serializer.is_valid()
+
+    serializer.save()
+
+    assert not models.Subscription.objects.filter(
+        pk=recipient_subscription.pk
+    ).exists()
+
+
+def test_validate_recipient_email_nonexistent(db):
+    """
+    If the provided recipient email does not exist in our database, a
+    validation error should be raised.
+    """
+    serializer = subscription_serializers.SubscriptionTransferSerializer()
+
+    with pytest.raises(ValidationError):
+        serializer.validate_recipient_email("does-not-exist@example.com")
+
+
+def test_validate_recipient_email_unverified(email_factory):
+    """
+    If the provided recipient email has not been verified, a validation
+    error should be raised.
+    """
+    email = email_factory(is_verified=False)
+    serializer = subscription_serializers.SubscriptionTransferSerializer()
+
+    with pytest.raises(ValidationError):
+        serializer.validate_recipient_email(email.email)
+
+
+def test_validate_active_premium_subscription(api_rf, user_factory):
+    """
+    If the recipient has an active premium subscription, a validation
+    error should be raised.
+    """
+    owner = user_factory(has_premium=True)
+    api_rf.user = owner
+    user = user_factory(has_premium=True)
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": api_rf.post("/")}
+    )
+    serializer.validate_recipient_email(user.primary_email.email)
+
+    with pytest.raises(ValidationError):
+        serializer.validate({"recipient_email": user.primary_email.email})
+
+
+def test_validate_apple_data(api_rf, apple_subscription_factory, user_factory):
+    """
+    If the recipient has an Apple receipt for a premium subscription on
+    file, then validation should fail.
+    """
+    owner = user_factory(has_premium=True)
+    api_rf.user = owner
+    apple_data = apple_subscription_factory(subscription__is_active=False)
+    user = apple_data.subscription.user
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": api_rf.post("/")}
+    )
+    serializer.validate_recipient_email(user.primary_email.email)
+
+    with pytest.raises(ValidationError):
+        serializer.validate({"recipient_email": user.primary_email.email})
+
+
+def test_validate_inactive_premium_subscription(
+    api_rf, subscription_factory, user_factory
+):
+    """
+    If the recipient has an associated subscription but it is inactive,
+    validation should pass.
+    """
+    owner = user_factory(has_premium=True)
+    api_rf.user = owner
+    subscription = subscription_factory(is_active=False)
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": api_rf.post("/")}
+    )
+    serializer.validate_recipient_email(subscription.user.primary_email.email)
+
+    result = serializer.validate(
+        {"recipient_email": subscription.user.primary_email.email}
+    )
+    expected = {"recipient_email": subscription.user.primary_email.email}
+
+    assert result == expected
+
+
+def test_validate_owner_inactive_subscription(
+    api_rf, subscription_factory, user_factory
+):
+    """
+    If the user initiating the transfer has an inactive subscription,
+    validation should fail.
+    """
+    owner = user_factory()
+    subscription_factory(is_active=False, user=owner)
+    api_rf.user = owner
+    recipient = user_factory()
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": api_rf.post("/")}
+    )
+    serializer.validate_recipient_email(recipient.primary_email.email)
+
+    with pytest.raises(ValidationError):
+        serializer.validate({"recipient_email": recipient.primary_email.email})
+
+
+def test_validate_owner_no_subscription(api_rf, user_factory):
+    """
+    If the user initiating the transfer does not have a subscription,
+    validation should fail.
+    """
+    owner = user_factory()
+    api_rf.user = owner
+    recipient = user_factory()
+
+    serializer = subscription_serializers.SubscriptionTransferSerializer(
+        context={"request": api_rf.post("/")}
+    )
+    serializer.validate_recipient_email(recipient.primary_email.email)
+
+    with pytest.raises(ValidationError):
+        serializer.validate({"recipient_email": recipient.primary_email.email})

--- a/km_api/know_me/tests/views/test_subscription_transfer_view.py
+++ b/km_api/know_me/tests/views/test_subscription_transfer_view.py
@@ -1,0 +1,12 @@
+from know_me import views
+from know_me.serializers import subscription_serializers
+
+
+def test_get_serializer_class():
+    """
+    Test which serializer class is used by the view.
+    """
+    view = views.SubscriptionTransferView()
+    expected = subscription_serializers.SubscriptionTransferSerializer
+
+    assert view.get_serializer_class() == expected

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -49,6 +49,11 @@ urlpatterns = [
         views.AppleSubscriptionView.as_view(),
         name="apple-subscription-detail",
     ),
+    path(
+        "subscription/transfer/",
+        views.SubscriptionTransferView.as_view(),
+        name="subscription-transfer-create",
+    ),
     url(r"^users/$", views.KMUserListView.as_view(), name="km-user-list"),
     url(
         r"^users/accessors/$",

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -1,13 +1,13 @@
 """Views for the ``know_me`` module.
 """
 
-from django.db.models import Case, Q, PositiveSmallIntegerField, Value, When
+from django.db.models import Case, PositiveSmallIntegerField, Q, Value, When
 from django.shortcuts import get_object_or_404
 from dry_rest_permissions.generics import DRYGlobalPermissions, DRYPermissions
 from rest_framework import generics, pagination, status
 from rest_framework.response import Response
 
-from know_me import models, serializers, permissions
+from know_me import models, permissions, serializers
 from know_me.serializers import subscription_serializers
 from permission_utils.view_mixins import DocumentActionMixin
 
@@ -357,3 +357,20 @@ class PendingAccessorListView(generics.ListAPIView):
             give access to the requesting user and are not yet accepted.
         """
         return self.request.user.km_user_accessors.filter(is_accepted=False)
+
+
+class SubscriptionTransferView(generics.CreateAPIView):
+    """
+    post:
+    Transfer a Know Me premium subscription to another user.
+
+    Requirements:
+    * The authenticated user must have an active Know Me premium
+      subscription.
+    * The specified recipient email address must exist in the system and
+      be verified.
+    * The recipient must not have an active premium subscription.
+    """
+
+    permission_classes = (permissions.HasPremium,)
+    serializer_class = subscription_serializers.SubscriptionTransferSerializer


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #396 


### Proposed Changes

This endpoint allows a user with an active premium subscription to transfer their subscription to another Know Me user using the recipient's email address.



<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
