### PR TITLE
Fix issue with adding Apple receipts for multiple users

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_get_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_get_apple_subscription.py
@@ -1,8 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from test_utils import serialized_time
-
+from test_utils import serialized_time, receipt_data_hash
 
 URL = reverse("know-me:apple-subscription-detail")
 
@@ -41,6 +40,7 @@ def test_get_existing_subscription(
         "expiration_time": serialized_time(subscription.expiration_time),
         "id": subscription.id,
         "receipt_data": subscription.receipt_data,
+        "receipt_data_hash": receipt_data_hash(subscription.receipt_data),
         "time_created": serialized_time(subscription.time_created),
         "time_updated": serialized_time(subscription.time_updated),
     }

--- a/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
@@ -3,11 +3,11 @@ import datetime
 import pytest
 from django.utils import timezone
 from rest_framework import status
-from rest_framework.reverse import reverse
 
 from test_utils import serialized_time
 
 PREMIUM_PRODUCT_CODE = "premium"
+URL = "/know-me/subscription/apple/"
 
 
 @pytest.fixture(autouse=True)
@@ -37,8 +37,7 @@ def test_set_duplicate_apple_receipt(
     # ...and attempts to upload the same receipt data that is already in
     # use...
     data = {"receipt_data": receipt_data}
-    url = reverse("know-me:apple-subscription-detail")
-    response = api_client.put(url, data)
+    response = api_client.put(URL, data)
 
     # ...then he should receive a 400 response with an error indicating
     # the receipt is already in use.
@@ -68,11 +67,68 @@ def test_set_invalid_apple_receipt(
     # ...then when she attempts to set her receipt for her Know Me
     # subscription to an invalid receipt...
     data = {"receipt_data": receipt_data}
-    url = reverse("know-me:apple-subscription-detail")
-    response = api_client.put(url, json=data)
+    response = api_client.put(URL, json=data)
 
     # ...she should receive a 400 response.
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_set_multiple_apple_receipts(
+    api_client, apple_receipt_client, user_factory
+):
+    """
+    Multiple users should be able to add an Apple receipt to their
+    account.
+
+    Regression test for #444
+    """
+    expires = timezone.now().replace(microsecond=0) + datetime.timedelta(
+        days=30
+    )
+    receipt_1 = "receipt-1"
+    receipt_2 = "receipt-2"
+
+    # Given two users, Sarah and John...
+    password = "password"
+    user1 = user_factory(first_name="Sarah", password=password)
+    user2 = user_factory(first_name="John", password=password)
+
+    # ...who both have valid receipts for recognized products...
+    apple_receipt_client.enqueue_status(
+        receipt_1,
+        {
+            "status": 0,
+            "latest_receipt_info": [
+                {
+                    "expires_date_ms": str(int(expires.timestamp() * 1000)),
+                    "product_id": PREMIUM_PRODUCT_CODE,
+                }
+            ],
+        },
+    )
+    apple_receipt_client.enqueue_status(
+        receipt_2,
+        {
+            "status": 0,
+            "latest_receipt_info": [
+                {
+                    "expires_date_ms": str(int(expires.timestamp() * 1000)),
+                    "product_id": PREMIUM_PRODUCT_CODE,
+                }
+            ],
+        },
+    )
+
+    # ...then both of them should be able to set Apple receipts.
+    api_client.log_in(user1.primary_email.email, password)
+    response = api_client.put(URL, json={"receipt_data": receipt_1})
+
+    assert response.status_code == status.HTTP_200_OK
+
+    api_client.log_in(user2.primary_email.email, password)
+    response = api_client.put(URL, json={"receipt_data": receipt_2})
+
+    assert response.status_code == status.HTTP_200_OK
 
 
 def test_set_valid_apple_receipt(
@@ -108,8 +164,7 @@ def test_set_valid_apple_receipt(
 
     # ...then when he sets that receipt as his Know Me subscription...
     data = {"receipt_data": receipt_data}
-    url = reverse("know-me:apple-subscription-detail")
-    response = api_client.put(url, json=data)
+    response = api_client.put(URL, json=data)
     response_data = response.json()
 
     # ...he should receive a 200 response.

--- a/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
@@ -4,7 +4,7 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from test_utils import serialized_time
+from test_utils import serialized_time, receipt_data_hash
 
 PREMIUM_PRODUCT_CODE = "premium"
 URL = "/know-me/subscription/apple/"
@@ -171,3 +171,6 @@ def test_set_valid_apple_receipt(
     assert response.status_code == status.HTTP_200_OK
     assert response_data["expiration_time"] == serialized_time(expires)
     assert response_data["receipt_data"] == receipt_data
+    assert response_data["receipt_data_hash"] == receipt_data_hash(
+        receipt_data
+    )

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -734,7 +734,11 @@ class SubscriptionAppleData(mixins.IsAuthenticatedMixin, models.Model):
                 A collection of fields to exclude from the uniqueness
                 check.
         """
-        super().validate_unique(exclude)
+        # For some reason the admin only uses our custom unique
+        # validation rather than the one in the super call so we
+        # exclude the default one.
+        exclude = exclude or []
+        super().validate_unique(exclude + ["receipt_data_hash"])
 
         if self.__class__.objects.filter(
             receipt_data_hash=self.receipt_data_hash

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -24,9 +24,10 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
             "time_updated",
             "expiration_time",
             "receipt_data",
+            "receipt_data_hash",
         )
         model = models.SubscriptionAppleData
-        read_only_fields = ("expiration_time",)
+        read_only_fields = ("expiration_time", "receipt_data_hash")
 
     def validate(self, data):
         """
@@ -43,7 +44,7 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
         if models.SubscriptionAppleData.objects.filter(
             receipt_data_hash=data_hash
         ).exists():
-            logger.warning(
+            logger.info(
                 "Duplicate Apple receipt submitted with hash: %s", data_hash
             )
 
@@ -63,6 +64,7 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
             )
 
         validated_data["expiration_time"] = receipt.expires_date
+        validated_data["receipt_data_hash"] = data_hash
 
         return validated_data
 

--- a/km_api/know_me/tests/serializers/test_apple_subscription_serializer.py
+++ b/km_api/know_me/tests/serializers/test_apple_subscription_serializer.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 from know_me import subscriptions
 from know_me.serializers import subscription_serializers
 from know_me.subscriptions import AppleReceipt
-from test_utils import serialized_time
+from test_utils import serialized_time, receipt_data_hash
 
 
 def test_serialize(apple_subscription_factory):
@@ -26,6 +26,7 @@ def test_serialize(apple_subscription_factory):
         "time_updated": serialized_time(subscription.time_updated),
         "expiration_time": serialized_time(subscription.expiration_time),
         "receipt_data": subscription.receipt_data,
+        "receipt_data_hash": receipt_data_hash(subscription.receipt_data),
     }
 
     assert serializer.data == expected

--- a/km_api/test_utils/__init__.py
+++ b/km_api/test_utils/__init__.py
@@ -1,3 +1,20 @@
+import hashlib
+
+
+def receipt_data_hash(data):
+    """
+    Get the hash of some receipt data.
+
+    Args:
+        data:
+            The receipt data to get the hash of.
+
+    Returns:
+        The SHA256 hash of the given data.
+    """
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
 def serialized_time(time):
     """
     Return a serialized version of a datetime instance in the format of


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Fixes #444


### Proposed Changes

Fix issues related to database integrity issues when uploading Apple receipts for multiple users. The root cause was that we were not saving the hash of the receipt data (which is the field we have our unique constraint on) which caused an error as soon as the second receipt (with a blank hash field) was added.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
