### PR TITLE
Handle orphan subscriptions during update process

### DIFF
--- a/km_api/know_me/management/commands/updatesubscriptions.py
+++ b/km_api/know_me/management/commands/updatesubscriptions.py
@@ -32,6 +32,16 @@ class Command(management.BaseCommand):
             **options:
                 Keyword arguments provided to the command.
         """
+        self.stdout.write(
+            "Deactivating all subscriptions without a receipt..."
+        )
+        orphan_sub_count = models.Subscription.objects.filter(
+            apple_data__isnull=True, is_active=True
+        ).update(is_active=False)
+        self.stdout.write(
+            f"Deactivated {orphan_sub_count} orphan subscription(s)."
+        )
+
         cutoff_time = timezone.now() + self.EXPIRATION_WINDOW
         self.stdout.write(
             f"Updating Apple subscriptions that expire before "

--- a/km_api/know_me/tests/management/commands/test_updatesubscriptions_command.py
+++ b/km_api/know_me/tests/management/commands/test_updatesubscriptions_command.py
@@ -123,3 +123,18 @@ def test_handle_still_expired_apple_subscription(
     apple_data.refresh_from_db()
 
     assert not apple_data.subscription.is_active
+
+
+def test_handle_subscription_no_receipt(subscription_factory):
+    """
+    If there is an active subscription without any receipt data (ie the
+    receipt data got deleted), it should be set to inactive when the
+    command is run.
+    """
+    subscription = subscription_factory(is_active=True)
+
+    command = Command()
+    command.handle()
+    subscription.refresh_from_db()
+
+    assert not subscription.is_active


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #445


### Proposed Changes

When updating subscriptions, any subscriptions that do not have an associated receipt are deactivated. This is a defense against cases where we forget to deactivate a subscription once its associated receipt
is deleted.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
