### PR TITLE
Allow users to delete their Apple receipt

### DIFF
--- a/km_api/functional_tests/conftest.py
+++ b/km_api/functional_tests/conftest.py
@@ -76,6 +76,22 @@ class APIClient(requests.Session):
 
         return super().request(method, url, **kwargs)
 
+    @property
+    def user_has_premium(self):
+        """
+        .. note:
+            For now, the authenticated user must have an associated
+            Know Me user in order for this check to be performed.
+
+        Returns:
+            A boolean indicating if the currently authenticated user has
+            an active premium subscription.
+        """
+        response = self.get("/know-me/users/")
+        response.raise_for_status()
+
+        return response.json()[0]["is_premium_user"]
+
 
 @pytest.fixture
 def api_client(live_server):

--- a/km_api/functional_tests/know_me/subscriptions/test_delete_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_delete_apple_subscription.py
@@ -1,0 +1,60 @@
+from rest_framework import status
+
+
+URL = "/know-me/subscription/apple/"
+
+
+def test_delete_anonymous(api_client):
+    """
+    If an anonymous user attempts to access the view they should receive
+    a 403 response.
+    """
+    response = api_client.delete(URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_delete_apple_subscription(
+    api_client, apple_subscription_factory, user_factory
+):
+    """
+    A user should be able to remove an Apple receipt they have
+    previously added to their account.
+    """
+    # Assume Matt is an existing user with an Apple receipt added to his
+    # account.
+    password = "password"
+    user = user_factory(
+        first_name="Matt",
+        has_premium=True,
+        password=password,
+        registration_signal__send=True,
+    )
+    apple_subscription_factory(subscription=user.know_me_subscription)
+
+    # If he deletes his Apple receipt, his premium subscription should be
+    # deactivated.
+    api_client.log_in(user.primary_email.email, password)
+    response = api_client.delete(URL)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not api_client.user_has_premium
+
+
+def test_delete_no_apple_subscription(api_client, user_factory):
+    """
+    If the requesting user does not have an Apple receipt uploaded, a
+    404 response should be returned.
+    """
+    # Assume Ashley is an existing user without a subscription.
+    password = "password"
+    user = user_factory(
+        first_name="Ashley", has_premium=True, password=password
+    )
+    api_client.log_in(user.primary_email.email, password)
+
+    # If she attempts to delete her non-existent Apple receipt, she
+    # should receive a 404 response.
+    response = api_client.delete(URL)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
@@ -3,24 +3,6 @@ from rest_framework import status
 TRANSFER_URL = "/know-me/subscription/transfer/"
 
 
-def user_is_premium(api_client):
-    """
-    Determine if the user logged in to the API client has a premium
-    subscription.
-
-    Args:
-        api_client:
-            The client to use to determine premium status.
-
-    Returns:
-        A boolean indicating if the user is a premium user.
-    """
-    response = api_client.get("/know-me/users/")
-    response.raise_for_status()
-
-    return response.json()[0]["is_premium_user"]
-
-
 def test_transfer_anonymous(api_client):
     """
     Anonymous users should receive a 403 response if they attempt to
@@ -159,9 +141,9 @@ def test_transfer_recipient_no_subscription(
     assert transfer_response.status_code == status.HTTP_201_CREATED
 
     # Shawn should no longer be a premium user.
-    assert not user_is_premium(api_client)
+    assert not api_client.user_has_premium
 
     # Juliet should be a premium user.
     api_client.log_in(user2.primary_email.email, password)
 
-    assert user_is_premium(api_client)
+    assert api_client.user_has_premium

--- a/km_api/know_me/factories.py
+++ b/km_api/know_me/factories.py
@@ -1,8 +1,10 @@
 """Factories to generate model instances for testing.
 """
+import datetime
 import hashlib
 
 import factory
+from django.utils import timezone
 
 
 class ConfigFactory(factory.django.DjangoModelFactory):
@@ -60,6 +62,9 @@ class SubscriptionAppleDataFactory(factory.django.DjangoModelFactory):
     Factory for generating ``SubscriptionAppleData`` instances.
     """
 
+    expiration_time = factory.LazyFunction(
+        lambda: timezone.now() + datetime.timedelta(minutes=30)
+    )
     receipt_data = "bogus receipt data"
     receipt_data_hash = factory.LazyAttribute(
         lambda instance: hashlib.sha256(

--- a/km_api/know_me/models.py
+++ b/km_api/know_me/models.py
@@ -714,17 +714,6 @@ class SubscriptionAppleData(mixins.IsAuthenticatedMixin, models.Model):
         """
         return request.user == self.subscription.user
 
-    def save(self, *args, **kwargs):
-        """
-        Update the base subscription's 'active' status based on the
-        Apple receipt's expiration date.
-        """
-        super().save(*args, **kwargs)
-
-        now = timezone.now()
-        self.subscription.is_active = self.expiration_time > now
-        self.subscription.save()
-
     def validate_unique(self, exclude=None):
         """
         Ensure that the receipt data for the instance is unique.

--- a/km_api/know_me/tests/management/commands/test_updatesubscriptions_command.py
+++ b/km_api/know_me/tests/management/commands/test_updatesubscriptions_command.py
@@ -37,9 +37,7 @@ def test_handle_expiring_apple_subscription(
     expires = timezone.now().replace(microsecond=0) - datetime.timedelta(
         days=30
     )
-    apple_data = apple_subscription_factory()
-    apple_data.subscription.is_active = True
-    apple_data.subscription.save()
+    apple_data = apple_subscription_factory(subscription__is_active=True)
 
     apple_receipt_client.enqueue_status(
         apple_data.receipt_data,

--- a/km_api/know_me/tests/models/test_subscription_apple_data_model.py
+++ b/km_api/know_me/tests/models/test_subscription_apple_data_model.py
@@ -1,10 +1,7 @@
-import datetime
 import hashlib
-from unittest import mock
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
 from know_me import models
 
@@ -70,48 +67,6 @@ def test_has_object_write_permission_other(
     request = api_rf.get("/")
 
     assert not subscription.has_object_write_permission(request)
-
-
-def test_save_update_base_subscription_active(apple_subscription_factory):
-    """
-    If the expiration date of the Apple subscription has not passed, the
-    base subscription should be made active when the Apple subscription
-    is saved.
-    """
-    future_time = timezone.now() + datetime.timedelta(days=1)
-
-    apple_subscription = apple_subscription_factory()
-    apple_subscription.expiration_time = future_time
-    apple_subscription.subscription.is_active = False
-
-    with mock.patch.object(
-        apple_subscription.subscription, "save"
-    ) as mock_save:
-        apple_subscription.save()
-
-    assert apple_subscription.subscription.is_active
-    assert mock_save.call_count == 1
-
-
-def test_save_update_base_subscription_expired(apple_subscription_factory):
-    """
-    If the expiration date of the Apple subscription has passed, the
-    base subscription should be made inactive when the Apple
-    subscription is saved.
-    """
-    past_time = timezone.now() - datetime.timedelta(days=1)
-
-    apple_subscription = apple_subscription_factory()
-    apple_subscription.expiration_time = past_time
-    apple_subscription.subscription.is_active = True
-
-    with mock.patch.object(
-        apple_subscription.subscription, "save"
-    ) as mock_save:
-        apple_subscription.save()
-
-    assert not apple_subscription.subscription.is_active
-    assert mock_save.call_count == 1
 
 
 def test_string_conversion(apple_subscription_factory):


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #437 


### Proposed Changes

If a user has previously added an Apple receipt for their premium subscription, they can now delete that receipt.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
