### PR TITLE
Add endpoint to get info about a subscription

### DIFF
--- a/km_api/functional_tests/conftest.py
+++ b/km_api/functional_tests/conftest.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 
 import pytest
 import requests
+from rest_framework import status
 from rest_framework.reverse import reverse
 
 
@@ -87,10 +88,14 @@ class APIClient(requests.Session):
             A boolean indicating if the currently authenticated user has
             an active premium subscription.
         """
-        response = self.get("/know-me/users/")
+        response = self.get("/know-me/subscription/")
+
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            return False
+
         response.raise_for_status()
 
-        return response.json()[0]["is_premium_user"]
+        return response.json()["is_active"]
 
 
 @pytest.fixture

--- a/km_api/functional_tests/know_me/subscriptions/test_delete_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_delete_apple_subscription.py
@@ -24,12 +24,7 @@ def test_delete_apple_subscription(
     # Assume Matt is an existing user with an Apple receipt added to his
     # account.
     password = "password"
-    user = user_factory(
-        first_name="Matt",
-        has_premium=True,
-        password=password,
-        registration_signal__send=True,
-    )
+    user = user_factory(first_name="Matt", has_premium=True, password=password)
     apple_subscription_factory(subscription=user.know_me_subscription)
 
     # If he deletes his Apple receipt, his premium subscription should be

--- a/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
@@ -1,0 +1,61 @@
+from rest_framework import status
+
+from test_utils import serialized_time
+
+URL = "/know-me/subscription/"
+
+
+def test_get_subscription_anonymous(api_client):
+    """
+    Anonymous users should receive a 403 response if they attempt to access
+    this endpoint.
+    """
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_subscription_apple_receipt(
+    api_client, apple_subscription_factory, user_factory
+):
+    """
+    If the requesting user has an Apple receipt as their payment source
+    for a premium subscription, info about it should be returned by the
+    overview endpoint.
+    """
+    # Assume Elijah is an existing user with an Apple receipt.
+    password = "password"
+    user = user_factory(first_name="Elijah", password=password)
+    apple_receipt = apple_subscription_factory(
+        subscription__is_active=True, subscription__user=user
+    )
+
+    # Elijah should now be able to get an overview of his subscription.
+    api_client.log_in(user.primary_email.email, password)
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "is_active": True,
+        "apple_receipt": {
+            "expiration_time": serialized_time(apple_receipt.expiration_time),
+            "receipt_data_hash": apple_receipt.receipt_data_hash,
+        },
+    }
+
+
+def test_get_subscription_non_existent(api_client, user_factory):
+    """
+    If the requesting user does not have a subscription, they should
+    receive a 404 response.
+    """
+    # Assume Anders is an existing user without a subscription.
+    password = "password"
+    user = user_factory(first_name="Anders", password=password)
+    api_client.log_in(user.primary_email.email, password)
+
+    # If he attempts to view the details of his non-existent
+    # subscription, he should receive a 404 response.
+    response = api_client.get(URL)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
@@ -122,14 +122,9 @@ def test_transfer_recipient_no_subscription(
     # active premium subscription.
     password = "password"
     user1 = user_factory(
-        first_name="Shawn",
-        has_premium=True,
-        password=password,
-        registration_signal__send=True,
+        first_name="Shawn", has_premium=True, password=password
     )
-    user2 = user_factory(
-        first_name="Juliet", password=password, registration_signal__send=True
-    )
+    user2 = user_factory(first_name="Juliet", password=password)
 
     # If Shawn logs in, he should be able to transfer his subscription
     # to Juliet.

--- a/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
@@ -1,0 +1,18 @@
+from know_me.serializers import subscription_serializers
+from test_utils import serialized_time
+
+
+def test_serialize(apple_subscription_factory):
+    """
+    Serializing an Apple receipt should return an overview of the
+    information contained in the receipt.
+    """
+    apple_receipt = apple_subscription_factory()
+    serializer = subscription_serializers.AppleReceiptInfoSerializer(
+        apple_receipt
+    )
+
+    assert serializer.data == {
+        "expiration_time": serialized_time(apple_receipt.expiration_time),
+        "receipt_data_hash": apple_receipt.receipt_data_hash,
+    }

--- a/km_api/know_me/journal/tests/serializers/test_subscription_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_subscription_serializer.py
@@ -1,0 +1,33 @@
+from know_me.serializers import subscription_serializers
+
+
+def test_serialize_inactive(subscription_factory):
+    """
+    If an inactive subscription is serialized, ``is_active`` should be
+    ``False`` and all other fields should be ``None``.
+    """
+    subscription = subscription_factory(is_active=False)
+    serializer = subscription_serializers.SubscriptionSerializer(subscription)
+
+    assert serializer.data == {"apple_receipt": None, "is_active": False}
+
+
+def test_serialize_apple_receipt(apple_subscription_factory):
+    """
+    If a subscription backed by an Apple receipt is serialized, it
+    should return information about the Apple receipt.
+    """
+    apple_receipt = apple_subscription_factory(subscription__is_active=True)
+    serializer = subscription_serializers.SubscriptionSerializer(
+        apple_receipt.subscription
+    )
+
+    # Child serializers
+    apple_receipt_serializer = subscription_serializers.AppleReceiptInfoSerializer(  # noqa
+        apple_receipt
+    )
+
+    assert serializer.data == {
+        "apple_receipt": apple_receipt_serializer.data,
+        "is_active": True,
+    }

--- a/km_api/know_me/journal/tests/views/test_subscription_detail_view.py
+++ b/km_api/know_me/journal/tests/views/test_subscription_detail_view.py
@@ -1,0 +1,43 @@
+import pytest
+from django.http import Http404
+
+from know_me import views
+from know_me.serializers import subscription_serializers
+
+
+def test_get_object(api_rf, subscription_factory):
+    """
+    If the requesting user has a subscription instance, it should be
+    returned.
+    """
+    subscription = subscription_factory()
+    api_rf.user = subscription.user
+
+    view = views.SubscriptionDetailView()
+    view.request = api_rf.get("/")
+
+    assert view.get_object() == subscription
+
+
+def test_get_object_non_existent(api_rf, user_factory):
+    """
+    If the requesting user does not have a subscription instance, an
+    ``Http404`` exception should be raised.
+    """
+    api_rf.user = user_factory()
+
+    view = views.SubscriptionDetailView()
+    view.request = api_rf.get("/")
+
+    with pytest.raises(Http404):
+        view.get_object()
+
+
+def test_get_serializer_class():
+    """
+    Test which serializer class is used by the view.
+    """
+    view = views.SubscriptionDetailView()
+    expected = subscription_serializers.SubscriptionSerializer
+
+    assert view.get_serializer_class() == expected

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -12,6 +12,17 @@ from know_me import models, subscriptions
 logger = logging.getLogger(__name__)
 
 
+class AppleReceiptInfoSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for getting information about an Apple receipt.
+    """
+
+    class Meta:
+        fields = ("expiration_time", "receipt_data_hash")
+        model = models.SubscriptionAppleData
+        read_only_fields = ("__all__",)
+
+
 class AppleSubscriptionSerializer(serializers.ModelSerializer):
     """
     Serializer for an Apple subscription.
@@ -67,6 +78,20 @@ class AppleSubscriptionSerializer(serializers.ModelSerializer):
         validated_data["receipt_data_hash"] = data_hash
 
         return validated_data
+
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+    """
+    Serializer for getting an overview of a user's Know Me premium
+    subscription.
+    """
+
+    apple_receipt = AppleReceiptInfoSerializer(source="apple_data")
+
+    class Meta:
+        fields = ("apple_receipt", "is_active")
+        model = models.Subscription
+        read_only_fields = ("__all__",)
 
 
 class SubscriptionTransferSerializer(serializers.Serializer):

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -45,6 +45,11 @@ urlpatterns = [
         name="legacy-user-detail",
     ),
     path(
+        "subscription/",
+        views.SubscriptionDetailView.as_view(),
+        name="subscription-detail",
+    ),
+    path(
         "subscription/apple/",
         views.AppleSubscriptionView.as_view(),
         name="apple-subscription-detail",

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -6,6 +6,7 @@ from django.db.models import Case, PositiveSmallIntegerField, Q, Value, When
 from django.shortcuts import get_object_or_404
 from dry_rest_permissions.generics import DRYGlobalPermissions, DRYPermissions
 from rest_framework import generics, pagination, status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from know_me import models, permissions, serializers
@@ -386,6 +387,29 @@ class PendingAccessorListView(generics.ListAPIView):
             give access to the requesting user and are not yet accepted.
         """
         return self.request.user.km_user_accessors.filter(is_accepted=False)
+
+
+class SubscriptionDetailView(generics.RetrieveAPIView):
+    """
+    get:
+    Get an overview of the requesting user's Know Me premium
+    subscription.
+    """
+
+    permission_classes = (IsAuthenticated,)
+    serializer_class = subscription_serializers.SubscriptionSerializer
+
+    def get_object(self):
+        """
+        Returns:
+            The subscription instance owned by the requesting user.
+
+        Raises:
+            Http404:
+                If the requesting user does not have a subscription
+                instance.
+        """
+        return get_object_or_404(models.Subscription, user=self.request.user)
 
 
 class SubscriptionTransferView(generics.CreateAPIView):


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #380


### Proposed Changes

Users can now view an overview of their subscription to get information such as if the subscription is active and what type of receipt is backing the subscription.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
