### PR TITLE
Add endpoint to check for Apple receipt existence

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
@@ -1,0 +1,31 @@
+import hashlib
+
+from rest_framework import status
+
+
+def test_apple_receipt_does_not_exist(api_client):
+    """
+    If there is no Apple receipt whose data hashes to the specified
+    value then a 404 response should be returned.
+    """
+    data_hash = hashlib.sha256("foo".encode()).hexdigest()
+    url = f"/know-me/subscription/apple/{data_hash}/"
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_apple_receipt_exists(api_client, apple_subscription_factory):
+    """
+    If an Apple subscription whose receipt data matches the provided
+    hash exists, a 200 response should be returned.
+    """
+    # Assume an Apple receipt for some user exists.
+    apple_receipt = apple_subscription_factory()
+
+    # Querying for that receipt by its hash should return a 200 response
+    # indicating it exists.
+    url = f"/know-me/subscription/apple/{apple_receipt.receipt_data_hash}/"
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK

--- a/km_api/know_me/tests/views/test_apple_receipt_query_view.py
+++ b/km_api/know_me/tests/views/test_apple_receipt_query_view.py
@@ -1,0 +1,35 @@
+import hashlib
+
+from rest_framework import status
+
+from know_me import views
+
+
+def test_get_hash_does_not_exist(db):
+    """
+    If there is no Apple receipt whose hash matches the one provided,
+    the response should have a 404 status code.
+    """
+    data_hash = hashlib.sha256("foo".encode()).hexdigest()
+
+    view = views.AppleReceiptQueryView()
+    view.kwargs = {"receipt_hash": data_hash}
+
+    response = view.get(None)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_hash_exists(apple_subscription_factory):
+    """
+    If an Apple receipt with the given hash exists, the returned
+    response should have a 200 status code.
+    """
+    receipt = apple_subscription_factory()
+
+    view = views.AppleReceiptQueryView()
+    view.kwargs = {"receipt_hash": receipt.receipt_data_hash}
+
+    response = view.get(None)
+
+    assert response.status_code == status.HTTP_200_OK

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -55,6 +55,11 @@ urlpatterns = [
         name="apple-subscription-detail",
     ),
     path(
+        "subscription/apple/<str:receipt_hash>/",
+        views.AppleReceiptQueryView.as_view(),
+        name="apple-receipt-query",
+    ),
+    path(
         "subscription/transfer/",
         views.SubscriptionTransferView.as_view(),
         name="subscription-transfer-create",


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #439


### Proposed Changes

API consumers can now check for the existence of an Apple receipt by providing the hash of its receipt data.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
