### PR TITLE
Fix warnings from `filter_fields` deprecation

### DIFF
--- a/km_api/functional_tests/conftest.py
+++ b/km_api/functional_tests/conftest.py
@@ -105,4 +105,8 @@ def api_client(live_server):
         An API client instance configured to interact with a live server
         for testing.
     """
-    return APIClient(live_server.url)
+    client = APIClient(live_server.url)
+
+    yield client
+
+    client.close()

--- a/km_api/know_me/journal/views.py
+++ b/km_api/know_me/journal/views.py
@@ -135,7 +135,7 @@ class EntryListView(generics.ListCreateAPIView):
     """
 
     filter_backends = (KMUserAccessFilterBackend, filters.DjangoFilterBackend)
-    filter_fields = {"created_at": ["gte", "lte"]}
+    filterset_fields = {"created_at": ["gte", "lte"]}
     pagination_class = pagination.PageNumberPagination
     permission_classes = (DRYPermissions, HasKMUserAccess)
     queryset = models.Entry.objects.all()

--- a/km_api/pytest.ini
+++ b/km_api/pytest.ini
@@ -2,4 +2,5 @@
 DJANGO_SETTINGS_MODULE = km_api.settings
 
 addopts = -n auto
+filterwarnings = error
 norecursedirs = email_templates functional_tests


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #435


### Proposed Changes

Fixed warnings due to `filter_fields` being renamed to `filterset_fields`. Additionally configured pytest to fail when warnings are emitted.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
