### PR TITLE
Fix usage of deprecated option for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 79
-py36 = true
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -15,3 +14,4 @@ exclude = '''
   | dist
 )/
 '''
+target-version = ['py36']


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #434 


### Proposed Changes

Fix usage of the `--py36` flag for `black` in favor of `--target-version py36`.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
