### PR TITLE
Gate ECS IP check behind environment flag

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -150,6 +150,15 @@ DJANGO_PASSWORD_RESET_URL
 
 The template used to construct password reset links. The ``{key}`` portion of the template will be replaced with a unique token.
 
+DJANGO_RUNNING_ON_ECS
+---------------------
+
+**Default:** ``False``
+
+A boolean indicating if the application is running as an ECS task. If it is, the
+application automatically adds the private IP of the ECS task to the list of
+allowed hosts.
+
 DJANGO_S3_AWS_REGION
 --------------------
 

--- a/km_api/km_api/settings.py
+++ b/km_api/km_api/settings.py
@@ -73,21 +73,14 @@ if allowed_host_string:
 # host machine running the task. This is needed because the load
 # balancer checks the status endpoint on the private IP rather than the
 # domain name we have set up.
-EC2_PRIVATE_IP = None
-
-try:
+if os.getenv("DJANGO_RUNNING_ON_ECS", "False").lower() == "true":
     resp = requests.get("http://169.254.170.2/v2/metadata")
     data = resp.json()
 
     container_meta = data["Containers"][0]
-    EC2_PRIVATE_IP = container_meta["Networks"][0]["IPv4Addresses"][0]
-# We catch all exceptions because any kind of failure here violates our
-# assumption that we are in an ECS cluster, so we want to silently fail.
-except:  # noqa
-    pass
+    private_ip = container_meta["Networks"][0]["IPv4Addresses"][0]
 
-if EC2_PRIVATE_IP:
-    ALLOWED_HOSTS.append(EC2_PRIVATE_IP)
+    ALLOWED_HOSTS.append(private_ip)
 
 
 # Application definition


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #459 


### Proposed Changes

Instead of always attempting to get the IP address of an ECS task and just continuing if we fail, we now require an environment variable to be set in order for us to get the IP.

The previous behavior was causing the slow CI builds because the network request to get the IP address of the ECS task had to timeout before we could continue and that took approximately 2 minutes per pytest invocation.

<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
