### PR TITLE
Fix subscription overview serializer

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
@@ -16,7 +16,7 @@ def test_get_subscription_anonymous(api_client):
 
 
 def test_get_subscription_apple_receipt(
-    api_client, apple_subscription_factory, user_factory
+    api_client, apple_receipt_factory, user_factory
 ):
     """
     If the requesting user has an Apple receipt as their payment source
@@ -26,7 +26,7 @@ def test_get_subscription_apple_receipt(
     # Assume Elijah is an existing user with an Apple receipt.
     password = "password"
     user = user_factory(first_name="Elijah", password=password)
-    apple_receipt = apple_subscription_factory(
+    apple_receipt = apple_receipt_factory(
         subscription__is_active=True, subscription__user=user
     )
 

--- a/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
@@ -1,18 +1,22 @@
+from django.utils import timezone
+
+from know_me import models
 from know_me.serializers import subscription_serializers
 from test_utils import serialized_time
 
 
-def test_serialize(apple_subscription_factory):
+def test_serialize():
     """
     Serializing an Apple receipt should return an overview of the
     information contained in the receipt.
     """
-    apple_receipt = apple_subscription_factory()
-    serializer = subscription_serializers.AppleReceiptInfoSerializer(
-        apple_receipt
+    receipt = models.AppleReceipt(
+        expiration_time=timezone.now(),
+        receipt_data_hash=models.AppleReceipt.hash_data("foo"),
     )
+    serializer = subscription_serializers.AppleReceiptInfoSerializer(receipt)
 
     assert serializer.data == {
-        "expiration_time": serialized_time(apple_receipt.expiration_time),
-        "receipt_data_hash": apple_receipt.receipt_data_hash,
+        "expiration_time": serialized_time(receipt.expiration_time),
+        "receipt_data_hash": receipt.receipt_data_hash,
     }

--- a/km_api/know_me/journal/tests/serializers/test_subscription_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_subscription_serializer.py
@@ -1,33 +1,34 @@
+from know_me import models
 from know_me.serializers import subscription_serializers
 
 
-def test_serialize_inactive(subscription_factory):
+def test_serialize_inactive():
     """
     If an inactive subscription is serialized, ``is_active`` should be
     ``False`` and all other fields should be ``None``.
     """
-    subscription = subscription_factory(is_active=False)
+    subscription = models.Subscription(is_active=False)
     serializer = subscription_serializers.SubscriptionSerializer(subscription)
 
     assert serializer.data == {"apple_receipt": None, "is_active": False}
 
 
-def test_serialize_apple_receipt(apple_subscription_factory):
+def test_serialize_apple_receipt(apple_receipt_factory):
     """
     If a subscription backed by an Apple receipt is serialized, it
     should return information about the Apple receipt.
     """
-    apple_receipt = apple_subscription_factory(subscription__is_active=True)
+    receipt = apple_receipt_factory(subscription__is_active=True)
     serializer = subscription_serializers.SubscriptionSerializer(
-        apple_receipt.subscription
+        receipt.subscription
     )
 
     # Child serializers
-    apple_receipt_serializer = subscription_serializers.AppleReceiptInfoSerializer(  # noqa
-        apple_receipt
+    receipt_serializer = subscription_serializers.AppleReceiptInfoSerializer(
+        receipt
     )
 
     assert serializer.data == {
-        "apple_receipt": apple_receipt_serializer.data,
+        "apple_receipt": receipt_serializer.data,
         "is_active": True,
     }

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -100,7 +100,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     subscription.
     """
 
-    apple_receipt = AppleReceiptInfoSerializer(source="apple_data")
+    apple_receipt = AppleReceiptInfoSerializer()
 
     class Meta:
         fields = ("apple_receipt", "is_active")


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #478 


### Proposed Changes

The overview was using the wrong model to display information about the Apple receipt backing a subscription.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
