### PR TITLE
Add email address to Apple receipt query response

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
@@ -29,3 +29,7 @@ def test_apple_receipt_exists(api_client, apple_receipt_factory):
     response = api_client.get(url)
 
     assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "email": apple_receipt.subscription.user.primary_email.email,
+        "receipt_data_hash": apple_receipt.receipt_data_hash,
+    }

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -24,6 +24,26 @@ class AppleReceiptInfoSerializer(serializers.ModelSerializer):
         read_only_fields = ("__all__",)
 
 
+class AppleReceiptQuerySerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for responding to Apple receipt queries.
+    """
+
+    email = serializers.EmailField(
+        help_text=_(
+            "The primary email address of the Know Me user who is using the "
+            "Apple receipt with the specified hash."
+        ),
+        read_only=True,
+        source="subscription.user.primary_email.email",
+    )
+
+    class Meta:
+        fields = ("email", "receipt_data_hash")
+        model = models.AppleReceipt
+        read_only_fields = ("__all__",)
+
+
 class AppleReceiptSerializer(serializers.ModelSerializer):
     """
     Serializer for an Apple receipt.

--- a/km_api/know_me/tests/serializers/test_apple_receipt_query_serializer.py
+++ b/km_api/know_me/tests/serializers/test_apple_receipt_query_serializer.py
@@ -1,0 +1,15 @@
+from know_me.serializers import subscription_serializers
+
+
+def test_serialize(apple_receipt_factory):
+    """
+    Serializing an Apple receipt in response to a query should return
+    the receipt's data hash and the owner's primary email address.
+    """
+    receipt = apple_receipt_factory()
+    serializer = subscription_serializers.AppleReceiptQuerySerializer(receipt)
+
+    assert serializer.data == {
+        "email": receipt.subscription.user.primary_email.email,
+        "receipt_data_hash": receipt.receipt_data_hash,
+    }

--- a/km_api/know_me/tests/views/test_apple_receipt_query_view.py
+++ b/km_api/know_me/tests/views/test_apple_receipt_query_view.py
@@ -1,43 +1,50 @@
-import hashlib
+from unittest import mock
 
-from rest_framework import status
+import pytest
+from django.http import Http404
 
-from know_me import views
+from know_me import models, views
+from know_me.serializers import subscription_serializers
 
 
-def test_get_hash_does_not_exist(mock_apple_receipt_qs):
+def test_get_object_does_not_exist(mock_apple_receipt_qs):
     """
-    If there is no Apple receipt whose hash matches the one provided,
-    the response should have a 404 status code.
+    If there is no receipt with the given data hash, an ``Http404``
+    exception should be raised.
     """
-    mock_apple_receipt_qs.exists.return_value = False
-    data_hash = hashlib.sha256("foo".encode()).hexdigest()
+    data_hash = models.AppleReceipt.hash_data("foo")
+    mock_apple_receipt_qs.get.side_effect = models.AppleReceipt.DoesNotExist
 
     view = views.AppleReceiptQueryView()
     view.kwargs = {"receipt_hash": data_hash}
 
-    response = view.get(None)
-
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert mock_apple_receipt_qs.filter.call_args[1] == {
-        "receipt_data_hash": data_hash
-    }
+    with pytest.raises(Http404):
+        view.get_object()
 
 
-def test_get_hash_exists(mock_apple_receipt_qs):
+def test_get_object_exists(mock_apple_receipt_qs):
     """
-    If an Apple receipt with the given hash exists, the returned
-    response should have a 200 status code.
+    If there is an Apple receipt with the given hash, it should be
+    returned.
     """
-    mock_apple_receipt_qs.exists.return_value = True
-    data_hash = hashlib.sha256("bar".encode()).hexdigest()
+    receipt = mock.Mock(name="Mock Receipt")
+    receipt.receipt_data_hash = models.AppleReceipt.hash_data("foo")
+    mock_apple_receipt_qs.get.return_value = receipt
 
     view = views.AppleReceiptQueryView()
-    view.kwargs = {"receipt_hash": data_hash}
+    view.kwargs = {"receipt_hash": receipt.receipt_data_hash}
 
-    response = view.get(None)
-
-    assert response.status_code == status.HTTP_200_OK
-    assert mock_apple_receipt_qs.filter.call_args[1] == {
-        "receipt_data_hash": data_hash
+    assert view.get_object() == receipt
+    assert mock_apple_receipt_qs.get.call_args[1] == {
+        "receipt_data_hash": receipt.receipt_data_hash
     }
+
+
+def test_get_serializer_class():
+    """
+    Test the serializer class used by the view.
+    """
+    expected = subscription_serializers.AppleReceiptQuerySerializer
+    view = views.AppleReceiptQueryView()
+
+    assert view.get_serializer_class() == expected

--- a/km_api/know_me/views.py
+++ b/km_api/know_me/views.py
@@ -12,7 +12,6 @@ from rest_framework import generics, pagination, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.schemas import AutoSchema
-from rest_framework.views import APIView
 
 from know_me import models, permissions, serializers
 from know_me.serializers import subscription_serializers
@@ -21,7 +20,7 @@ from permission_utils.view_mixins import DocumentActionMixin
 logger = logging.getLogger(__name__)
 
 
-class AppleReceiptQueryView(APIView):
+class AppleReceiptQueryView(generics.RetrieveAPIView):
     """
     get:
     Determine if an Apple receipt is in use. If a 200 response is
@@ -46,19 +45,23 @@ class AppleReceiptQueryView(APIView):
                         "should be encoded as hexadecimal characters."
                     )
                 ),
+                type="String",
             )
         ]
     )
+    serializer_class = subscription_serializers.AppleReceiptQuerySerializer
 
-    def get(self, request, *args, **kwargs):
-        receipt_hash = self.kwargs["receipt_hash"]
+    def get_object(self):
+        """
+        Get the Apple receipt with the given hash.
 
-        exists = models.AppleReceipt.objects.filter(
-            receipt_data_hash=receipt_hash
-        ).exists()
-        code = status.HTTP_200_OK if exists else status.HTTP_404_NOT_FOUND
-
-        return Response(status=code)
+        Returns:
+            The :class:`AppleReceipt` instance with the given receipt
+            data hash.
+        """
+        return get_object_or_404(
+            models.AppleReceipt, receipt_data_hash=self.kwargs["receipt_hash"]
+        )
 
 
 class AppleSubscriptionView(generics.RetrieveDestroyAPIView):


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #477


### Proposed Changes

The email address of the Know Me user who owns an Apple receipt is now returned from the Apple receipt query endpoint.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
