### PR TITLE
Fix expired Apple receipts activating premium

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/knowmetools/km-api/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import transaction
+from django.utils import timezone
 from django.utils.translation import ugettext, ugettext_lazy as _
 from rest_email_auth.models import EmailAddress
 from rest_framework import serializers
@@ -77,7 +78,7 @@ class AppleReceiptSerializer(serializers.ModelSerializer):
                 The subscription to associate the Apple receipt being
                 saved with.
         """
-        subscription.is_active = True
+        subscription.is_active = self.instance.expiration_time > timezone.now()
         subscription.save()
         self.instance.subscription = subscription
         self.instance.save()


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #481


### Proposed Changes

Uploading an expired Apple subscription no longer activates the user's premium subscription.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
