### PR TITLE
Fix issue with transfering subscriptions

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_transfer_subscription.py
@@ -72,11 +72,8 @@ def test_transfer_recipient_active_subscription(
     }
 
 
-def test_transfer_recipient_apple_data(
-    api_client,
-    enable_premium_requirement,
-    apple_subscription_factory,
-    user_factory,
+def test_transfer_recipient_apple_receipt(
+    api_client, apple_receipt_factory, enable_premium_requirement, user_factory
 ):
     """
     If the intended recipient has an Apple receipt associated with their
@@ -93,7 +90,7 @@ def test_transfer_recipient_apple_data(
     # ...and Juliet is a user with an inactive premium subscription but
     # who has an Apple receipt tied to her account.
     user2 = user_factory(first_name="Juliet", password=password)
-    apple_subscription_factory(
+    apple_receipt_factory(
         subscription__is_active=False, subscription__user=user2
     )
 

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -207,7 +207,7 @@ class SubscriptionTransferSerializer(serializers.Serializer):
                 )
             )
 
-        if models.SubscriptionAppleData.objects.filter(
+        if models.AppleReceipt.objects.filter(
             subscription__user=self._recipient_email_inst.user
         ).exists():
             raise serializers.ValidationError(

--- a/km_api/know_me/tests/serializers/test_subscription_transfer_serializer.py
+++ b/km_api/know_me/tests/serializers/test_subscription_transfer_serializer.py
@@ -102,15 +102,15 @@ def test_validate_active_premium_subscription(api_rf, user_factory):
         serializer.validate({"recipient_email": user.primary_email.email})
 
 
-def test_validate_apple_data(api_rf, apple_subscription_factory, user_factory):
+def test_validate_apple_data(api_rf, apple_receipt_factory, user_factory):
     """
     If the recipient has an Apple receipt for a premium subscription on
     file, then validation should fail.
     """
     owner = user_factory(has_premium=True)
     api_rf.user = owner
-    apple_data = apple_subscription_factory(subscription__is_active=False)
-    user = apple_data.subscription.user
+    receipt = apple_receipt_factory(subscription__is_active=False)
+    user = receipt.subscription.user
 
     serializer = subscription_serializers.SubscriptionTransferSerializer(
         context={"request": api_rf.post("/")}


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #493


### Proposed Changes

The transfer process was using the old model of tracking Apple receipts
to check for an existing Apple subscription. This commit corrects the
check to use the updated model.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
