### PR TITLE
Implement new method of querying Apple receipts

### DIFF
--- a/km_api/know_me/tests/permissions/test_has_premium.py
+++ b/km_api/know_me/tests/permissions/test_has_premium.py
@@ -83,6 +83,7 @@ def test_has_permission_no_subscription(
     assert not perm.has_permission(request, view)
 
 
+# TODO: Fix this
 def test_has_permission_no_subscription_feature_disabled(api_rf):
     """
     If the

--- a/km_api/know_me/tests/serializers/test_apple_receipt_query_serializer.py
+++ b/km_api/know_me/tests/serializers/test_apple_receipt_query_serializer.py
@@ -1,15 +1,111 @@
+from unittest import mock
+
+import pytest
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from know_me import models
 from know_me.serializers import subscription_serializers
+from know_me.subscriptions import ReceiptException, AppleTransaction
 
 
-def test_serialize(apple_receipt_factory):
+def test_save():
     """
-    Serializing an Apple receipt in response to a query should return
-    the receipt's data hash and the owner's primary email address.
+    The save method of the serializer should be a no-op and thus
+    callable from an empty serializer.
     """
-    receipt = apple_receipt_factory()
-    serializer = subscription_serializers.AppleReceiptQuerySerializer(receipt)
+    serializer = subscription_serializers.AppleReceiptQuerySerializer()
+    serializer.save()
 
-    assert serializer.data == {
-        "email": receipt.subscription.user.primary_email.email,
-        "receipt_data_hash": receipt.receipt_data_hash,
+
+def test_validate_in_use(mock_apple_receipt_qs):
+    """
+    If there is an existing Apple receipt with the same original
+    transaction ID as the submitted receipt, the validated data's
+    ``is_used`` flag should be ``True`` and the ``email`` field should
+    be populated.
+    """
+    email = "test@example.com"
+    email_inst = mock.Mock()
+    email_inst.email = email
+    receipt = mock.Mock()
+    type(receipt.subscription.user).primary_email = mock.PropertyMock(
+        return_value=email_inst
+    )
+
+    mock_apple_receipt_qs.get.return_value = receipt
+
+    serializer = subscription_serializers.AppleReceiptQuerySerializer()
+    serializer._receipt_info = AppleTransaction(
+        {"original_transaction_id": receipt.transaction_id}, "foo"
+    )
+
+    validated = serializer.validate({"receipt_data": "foo"})
+
+    assert validated["email"] == email
+    assert validated["is_used"]
+    assert mock_apple_receipt_qs.get.call_args[1] == {
+        "transaction_id": serializer._receipt_info.original_transaction_id
     }
+
+
+def test_validate_not_used(mock_apple_receipt_qs):
+    """
+    If there is not an existing Apple receipt with the same original
+    transaction ID as the submitted receipt, the validated data's
+    ``is_used`` flag should be ``False`` and the ``email`` field should
+    not be populated.
+    """
+    mock_apple_receipt_qs.get.side_effect = models.AppleReceipt.DoesNotExist
+
+    serializer = subscription_serializers.AppleReceiptQuerySerializer()
+    serializer._receipt_info = AppleTransaction(
+        {"original_transaction_id": "abc"}, "foo"
+    )
+
+    validated = serializer.validate({"receipt_data": "foo"})
+
+    assert validated["email"] is None
+    assert not validated["is_used"]
+    assert mock_apple_receipt_qs.get.call_args[1] == {
+        "transaction_id": serializer._receipt_info.original_transaction_id
+    }
+
+
+@mock.patch(
+    "know_me.serializers.subscription_serializers.subscriptions.validate_apple_receipt",  # noqa
+    autospec=True,
+)
+def test_validate_receipt_data_invalid(mock_validate):
+    """
+    If the provided receipt data is invalid, a validation error should
+    be raised with the information from the receipt validation error.
+    """
+    exception = ReceiptException("foo", "bar")
+    mock_validate.side_effect = exception
+
+    serializer = subscription_serializers.AppleReceiptQuerySerializer()
+
+    with pytest.raises(DRFValidationError) as exc_info:
+        serializer.validate_receipt_data("baz")
+
+    assert exc_info.value.detail[0] == exception.msg
+    assert exc_info.value.detail[0].code == exception.code
+
+
+@mock.patch(
+    "know_me.serializers.subscription_serializers.subscriptions.validate_apple_receipt",  # noqa
+    autospec=True,
+)
+def test_validate_receipt_data_valid(mock_validate):
+    """
+    If the provided apple receipt is valid, validating it should persist
+    the receipt's data within the serializer.
+    """
+    receipt_data = "foo"
+    serializer = subscription_serializers.AppleReceiptQuerySerializer()
+
+    result = serializer.validate_receipt_data(receipt_data)
+
+    assert result == receipt_data
+    assert mock_validate.call_args[0] == (receipt_data,)
+    assert serializer._receipt_info == mock_validate.return_value

--- a/km_api/know_me/tests/views/test_apple_receipt_query_view.py
+++ b/km_api/know_me/tests/views/test_apple_receipt_query_view.py
@@ -1,43 +1,23 @@
 from unittest import mock
 
-import pytest
-from django.http import Http404
+from rest_framework import status
 
-from know_me import models, views
+from know_me import views
 from know_me.serializers import subscription_serializers
 
 
-def test_get_object_does_not_exist(mock_apple_receipt_qs):
+@mock.patch("know_me.views.generics.CreateAPIView.create", autospec=True)
+def test_create(mock_create):
     """
-    If there is no receipt with the given data hash, an ``Http404``
-    exception should be raised.
+    The create method of the view should take the response output by its
+    parent class' ``create`` method and set its status code to 200.
     """
-    data_hash = models.AppleReceipt.hash_data("foo")
-    mock_apple_receipt_qs.get.side_effect = models.AppleReceipt.DoesNotExist
-
     view = views.AppleReceiptQueryView()
-    view.kwargs = {"receipt_hash": data_hash}
 
-    with pytest.raises(Http404):
-        view.get_object()
+    response = view.create(None)
 
-
-def test_get_object_exists(mock_apple_receipt_qs):
-    """
-    If there is an Apple receipt with the given hash, it should be
-    returned.
-    """
-    receipt = mock.Mock(name="Mock Receipt")
-    receipt.receipt_data_hash = models.AppleReceipt.hash_data("foo")
-    mock_apple_receipt_qs.get.return_value = receipt
-
-    view = views.AppleReceiptQueryView()
-    view.kwargs = {"receipt_hash": receipt.receipt_data_hash}
-
-    assert view.get_object() == receipt
-    assert mock_apple_receipt_qs.get.call_args[1] == {
-        "receipt_data_hash": receipt.receipt_data_hash
-    }
+    assert response == mock_create.return_value
+    assert response.status_code == status.HTTP_200_OK
 
 
 def test_get_serializer_class():


### PR DESCRIPTION

<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #497


### Proposed Changes

Querying for Apple receipts now uses the original transaction ID to
check for existence rather than comparing receipt data hashes.



<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
