### PR TITLE
Remove hash fields from Apple receipt responses

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_get_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_get_apple_subscription.py
@@ -1,7 +1,8 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from test_utils import serialized_time, receipt_data_hash
+from test_utils import serialized_time
+
 
 URL = reverse("know-me:apple-subscription-detail")
 
@@ -40,7 +41,6 @@ def test_get_existing_subscription(
         "expiration_time": serialized_time(receipt.expiration_time),
         "id": str(receipt.pk),
         "receipt_data": receipt.receipt_data,
-        "receipt_data_hash": receipt_data_hash(receipt.receipt_data),
         "time_created": serialized_time(receipt.time_created),
         "time_updated": serialized_time(receipt.time_updated),
     }

--- a/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_get_subscription_overview.py
@@ -2,6 +2,7 @@ from rest_framework import status
 
 from test_utils import serialized_time
 
+
 URL = "/know-me/subscription/"
 
 
@@ -37,8 +38,7 @@ def test_get_subscription_apple_receipt(
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         "apple_receipt": {
-            "expiration_time": serialized_time(apple_receipt.expiration_time),
-            "receipt_data_hash": apple_receipt.receipt_data_hash,
+            "expiration_time": serialized_time(apple_receipt.expiration_time)
         },
         "is_active": True,
         "is_legacy_subscription": False,

--- a/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_set_apple_subscription.py
@@ -4,7 +4,7 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from test_utils import serialized_time, receipt_data_hash
+from test_utils import serialized_time
 
 
 PREMIUM_PRODUCT_CODE = "premium"
@@ -237,9 +237,6 @@ def test_set_valid_apple_receipt(
     assert response.status_code == status.HTTP_200_OK
     assert response_data["expiration_time"] == serialized_time(expires)
     assert response_data["receipt_data"] == receipt_data
-    assert response_data["receipt_data_hash"] == receipt_data_hash(
-        receipt_data
-    )
 
 
 def test_set_valid_apple_receipt_activates_subscription(
@@ -288,9 +285,6 @@ def test_set_valid_apple_receipt_activates_subscription(
     assert response.status_code == status.HTTP_200_OK
     assert response_data["expiration_time"] == serialized_time(expires)
     assert response_data["receipt_data"] == receipt_data
-    assert response_data["receipt_data_hash"] == receipt_data_hash(
-        receipt_data
-    )
 
     # ...and her subscription should be set to active.
     response = api_client.get("/know-me/subscription/")

--- a/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
+++ b/km_api/know_me/journal/tests/serializers/test_apple_receipt_info_serializer.py
@@ -10,13 +10,9 @@ def test_serialize():
     Serializing an Apple receipt should return an overview of the
     information contained in the receipt.
     """
-    receipt = models.AppleReceipt(
-        expiration_time=timezone.now(),
-        receipt_data_hash=models.AppleReceipt.hash_data("foo"),
-    )
+    receipt = models.AppleReceipt(expiration_time=timezone.now())
     serializer = subscription_serializers.AppleReceiptInfoSerializer(receipt)
 
     assert serializer.data == {
-        "expiration_time": serialized_time(receipt.expiration_time),
-        "receipt_data_hash": receipt.receipt_data_hash,
+        "expiration_time": serialized_time(receipt.expiration_time)
     }

--- a/km_api/know_me/serializers/subscription_serializers.py
+++ b/km_api/know_me/serializers/subscription_serializers.py
@@ -20,7 +20,7 @@ class AppleReceiptInfoSerializer(serializers.ModelSerializer):
     """
 
     class Meta:
-        fields = ("expiration_time", "receipt_data_hash")
+        fields = ("expiration_time",)
         model = models.SubscriptionAppleData
         read_only_fields = ("__all__",)
 
@@ -125,13 +125,11 @@ class AppleReceiptSerializer(serializers.ModelSerializer):
             "time_updated",
             "expiration_time",
             "receipt_data",
-            "receipt_data_hash",
         )
         model = models.AppleReceipt
         read_only_fields = (
             "expiration_time",
             "id",
-            "receipt_data_hash",
             "time_created",
             "time_updated",
         )

--- a/km_api/know_me/tests/serializers/test_apple_receipt_serializer.py
+++ b/km_api/know_me/tests/serializers/test_apple_receipt_serializer.py
@@ -103,7 +103,6 @@ def test_serialize():
         "time_updated": serialized_time(receipt.time_updated),
         "expiration_time": serialized_time(receipt.expiration_time),
         "receipt_data": receipt.receipt_data,
-        "receipt_data_hash": receipt.hash_data(receipt.receipt_data),
     }
 
     assert serializer.data == expected


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #499


### Proposed Changes

This PR removes all information pertaining to the hash of an Apple receipt's data from responses.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
