### PR TITLE
Add legacy user flag to Know Me users

### DIFF
--- a/km_api/functional_tests/serialization_helpers.py
+++ b/km_api/functional_tests/serialization_helpers.py
@@ -94,6 +94,7 @@ def km_user_list(km_users, is_owned_by_user, build_full_url):
             "url": build_full_url(f"/know-me/users/{user.pk}/"),
             "created_at": serialized_time(user.created_at),
             "updated_at": serialized_time(user.updated_at),
+            "is_legacy_user": user.is_legacy_user,
             "is_premium_user": user.is_premium_user,
             "is_owned_by_current_user": is_owned_by_user(user),
             "image": build_full_file_url(user.image, build_full_url),

--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -77,6 +77,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             "url",
             "created_at",
             "updated_at",
+            "is_legacy_user",
             "is_premium_user",
             "is_owned_by_current_user",
             "image",
@@ -89,6 +90,7 @@ class KMUserListSerializer(serializers.HyperlinkedModelSerializer):
             "user_image",
         )
         model = models.KMUser
+        read_only_fields = ("is_legacy_user",)
 
     def get_is_owned_by_current_user(self, km_user):
         """

--- a/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_list_serializer.py
@@ -80,6 +80,7 @@ def test_serialize(
         "created_at": serialized_time(km_user.created_at),
         "updated_at": serialized_time(km_user.updated_at),
         "image": image_url,
+        "is_legacy_user": km_user.is_legacy_user,
         "is_premium_user": km_user.is_premium_user,
         "is_owned_by_current_user": km_user.user == request.user,
         "journal_entries_url": entries_url,


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #488


### Proposed Changes

The list and detail representations of a Know Me user now include an `is_legacy_user` flag.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
