### PR TITLE
Add logic to handle cancelled Apple receipts

### DIFF
--- a/km_api/know_me/subscriptions.py
+++ b/km_api/know_me/subscriptions.py
@@ -69,6 +69,14 @@ class ReceiptException(Exception):
         self.code = code
 
 
+class CancelledReceiptException(ReceiptException):
+    """
+    Exception indicating a receipt was cancelled by Apple support.
+    """
+
+    pass
+
+
 class InvalidReceiptTypeException(ReceiptException):
     """
     Exception indicating the wrong type of receipt was provided.
@@ -274,8 +282,13 @@ def validate_apple_receipt_response(receipt_response):
         )
 
     latest_transaction = latest_receipts[-1]
-    product = latest_transaction.get("product_id")
 
+    if latest_transaction.get("cancellation_date", None):
+        raise CancelledReceiptException(
+            ugettext("This subscription has been cancelled by Apple.")
+        )
+
+    product = latest_transaction.get("product_id")
     if product not in settings.APPLE_PRODUCT_CODES["KNOW_ME_PREMIUM"]:
         logger.info(
             "Received receipt that included a transaction for the unknown "


### PR DESCRIPTION
<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #474


### Proposed Changes

Receipts cancelled by Apple customer support are now correctly handled.
Attempting to upload a receipt that has been cancelled will now reject
the upload, and cancelled receipts are deleted by the background job
used to update subscriptions.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
