### PR TITLE
Restrict URL for Apple receipt queries

### DIFF
--- a/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
+++ b/km_api/functional_tests/know_me/subscriptions/test_query_apple_receipt_exists.py
@@ -82,3 +82,15 @@ def test_apple_receipt_exists(
         "email": receipt.subscription.user.primary_email.email,
         "is_used": True,
     }
+
+
+def test_wrong_endpoint(api_client):
+    """
+    Attempting to query using the wrong endpoint should return a 404
+    response.
+
+    Regression test for #505.
+    """
+    response = api_client.post("/know-me/subscription/apple/foobar/", {})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/km_api/know_me/urls.py
+++ b/km_api/know_me/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
         name="apple-subscription-detail",
     ),
     path(
-        "subscription/apple/<str:receipt_hash>/",
+        "subscription/apple/query/",
         views.AppleReceiptQueryView.as_view(),
         name="apple-receipt-query",
     ),


### PR DESCRIPTION

<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #505


### Proposed Changes

Querying for an Apple receipt is now only available at the URL:

/know-me/subscription/apple/query/



<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
