### PR TITLE
Add Know Me user ID to accessor representation

### DIFF
--- a/km_api/functional_tests/serialization_helpers.py
+++ b/km_api/functional_tests/serialization_helpers.py
@@ -37,6 +37,7 @@ def km_user_accessor(
         "is_accepted": accessor.is_accepted,
         "is_admin": accessor.is_admin,
         "km_user": {
+            "id": accessor.km_user.pk,
             "image": build_full_file_url(
                 accessor.km_user.image, build_full_url
             ),

--- a/km_api/know_me/serializers/__init__.py
+++ b/km_api/know_me/serializers/__init__.py
@@ -35,7 +35,7 @@ class KMUserInfoSerializer(serializers.ModelSerializer):
     """
 
     class Meta:
-        fields = ("image", "name")
+        fields = ("id", "image", "name")
         model = models.KMUser
 
 

--- a/km_api/know_me/tests/serializers/test_km_user_info_serializer.py
+++ b/km_api/know_me/tests/serializers/test_km_user_info_serializer.py
@@ -15,6 +15,6 @@ def test_serialize(api_rf, image, km_user_factory):
     image_request = api_rf.get(km_user.image.url)
     image_url = image_request.build_absolute_uri()
 
-    expected = {"image": image_url, "name": km_user.name}
+    expected = {"id": km_user.pk, "image": image_url, "name": km_user.name}
 
     assert serializer.data == expected


### PR DESCRIPTION


<!--
If there is no issue to reference for the proposed changes, please consider opening one so we can discuss if the changes are needed.
-->

Closes #512


### Proposed Changes

The Know Me user representation returned with an accessor now includes
the ID of the user.


<!--

If this pull request is a work in progress, you can include a list of items left to complete.

##### TODO

If your pull request is still a WIP, include a basic list of tasks that must be completed before the pull request should be considered.

- [x] completed task
- [ ] incomplete task

-->
